### PR TITLE
Add `skip_serializing` on `#[serde(other)]` variants; update some docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Breaking Changes
 - Minimum Rust version required is 1.31.1.
 - Moved `retrieve_source` and `detach_source` to `Customer` resource from `Source`.
+- The `Error::Conversion` enum variant has been replaced by `Error::Serialize` and `Error::Deserialize`.
 
 # Version 0.7.2
 

--- a/stripe/src/params.rs
+++ b/stripe/src/params.rs
@@ -30,9 +30,13 @@ impl<T: DeserializeOwned> List<T> {
     /// Prefer `List::next` when possible
     pub fn get_next(client: &Client, url: &str, last_id: &str) -> Result<List<T>, Error> {
         if url.starts_with("/v1/") {
+            // TODO: Maybe parse the URL?  Perhaps `List` should always parse its `url` field.
             let mut url = url.trim_left_matches("/v1/").to_string();
-            url.push_str(&format!("?starting_after={}", last_id));
-
+            if url.contains("?") {
+                url.push_str(&format!("&starting_after={}", last_id));
+            } else {
+                url.push_str(&format!("?starting_after={}", last_id));
+            }
             client.get(&url)
         } else {
             Err(Error::Unsupported("URL for fetching additional data uses different API version"))

--- a/stripe/src/resources/card.rs
+++ b/stripe/src/resources/card.rs
@@ -110,6 +110,9 @@ pub enum CardBrand {
     #[serde(rename = "UnionPay")]
     UnionPay,
 
+    /// An unknown card brand.
+    ///
+    /// May also be a variant not yet supported by the library.
     #[serde(other)]
     #[serde(rename = "Unknown")]
     Unknown,
@@ -124,6 +127,9 @@ pub enum CardType {
     #[serde(rename = "prepaid")]
     Prepaid,
 
+    /// An unknown card type.
+    ///
+    /// May also be a variant not yet supported by the library.
     #[serde(other)]
     #[serde(rename = "unknown")]
     Unknown,
@@ -135,8 +141,10 @@ pub enum TokenizationMethod {
     ApplePay,
     AndroidPay,
 
-    #[serde(other)]
-    Unknown,
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
+    Other,
 }
 
 impl Identifiable for Card {

--- a/stripe/src/resources/charge.rs
+++ b/stripe/src/resources/charge.rs
@@ -2,7 +2,6 @@ use client::Client;
 use error::{Error, ErrorCode};
 use params::{Identifiable, List, Metadata, RangeQuery, Timestamp};
 use resources::{Address, Currency, PaymentSource, PaymentSourceParams, Refund};
-use serde_qs as qs;
 
 /// The resource representing a Stripe charge object outcome.
 ///
@@ -341,7 +340,7 @@ impl Charge {
     ///
     /// For more details see [https://stripe.com/docs/api#create_charge](https://stripe.com/docs/api#create_charge).
     pub fn create(client: &Client, params: ChargeParams) -> Result<Charge, Error> {
-        client.post("/charges", params)
+        client.post_form("/charges", params)
     }
 
     /// Retrieves the details of a charge.
@@ -355,7 +354,7 @@ impl Charge {
     ///
     /// For more details see [https://stripe.com/docs/api#update_charge](https://stripe.com/docs/api#update_charge).
     pub fn update(client: &Client, charge_id: &str, params: ChargeParams) -> Result<Charge, Error> {
-        client.post(&format!("/charges/{}", charge_id), params)
+        client.post_form(&format!("/charges/{}", charge_id), params)
     }
 
     /// Capture captures a previously created charge with capture set to false.
@@ -366,13 +365,13 @@ impl Charge {
         charge_id: &str,
         params: CaptureParams,
     ) -> Result<Charge, Error> {
-        client.post(&format!("/charges/{}/capture", charge_id), params)
+        client.post_form(&format!("/charges/{}/capture", charge_id), params)
     }
 
     /// List all charges.
     ///
     /// For more details see [https://stripe.com/docs/api#list_charges](https://stripe.com/docs/api#list_charges).
     pub fn list(client: &Client, params: ChargeListParams) -> Result<Vec<Charge>, Error> {
-        client.get(&format!("/charges?{}", qs::to_string(&params)?))
+        client.get_query("/charges", &params)
     }
 }

--- a/stripe/src/resources/charge.rs
+++ b/stripe/src/resources/charge.rs
@@ -70,10 +70,12 @@ pub enum RiskLevel {
     Highest,
     NotAssessed,
 
-    /// A variant not yet supported by the library.
-    /// It is an error to send `Other` as part of a request.
-    #[serde(other, skip_serializing)]
-    Other,
+    /// An unknown risk level.
+    ///
+    /// May also be a variant not yet supported by the library.
+    #[serde(other)]
+    #[serde(rename = "unknown")]
+    Unknown,
 }
 
 /// An enum representing the possible values of a `ChargeOutcome`'s `reason` field.

--- a/stripe/src/resources/charge.rs
+++ b/stripe/src/resources/charge.rs
@@ -33,7 +33,10 @@ pub enum OutcomeType {
     IssuerDeclined,
     Blocked,
     Invalid,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -46,8 +49,14 @@ pub enum NetworkStatus {
     ApprovedByNetwork,
     DeclinedByNetwork,
     NotSentToNetwork,
+
+    /// This value indiciates the payment was [blocked by Stripe](https://stripe.com/docs/declines#blocked-payments)
+    /// after bank authorization, and may temporarily appear as “pending” on a cardholder’s statement.
     ReversedAfterApproval,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -61,8 +70,11 @@ pub enum RiskLevel {
     Elevated,
     Highest,
     NotAssessed,
-    #[serde(other)]
-    Unknown
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
+    Other,
 }
 
 /// An enum representing the possible values of a `ChargeOutcome`'s `reason` field.
@@ -114,7 +126,10 @@ pub enum OutcomeReason {
     TransactionNotAllowed,
     TryAgainLater,
     WithdrawalCountLimitExceeded,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 

--- a/stripe/src/resources/customer.rs
+++ b/stripe/src/resources/customer.rs
@@ -139,7 +139,6 @@ impl Customer {
     }
 
     /// Retrieves a Card, BankAccount, or Source for a Customer
-    /// 
     pub fn retrieve_source(
         client: &Client,
         customer_id: &str,
@@ -157,7 +156,7 @@ impl Customer {
         bank_account_id: &BankAccountId,
         params: BankAccountVerifyParams,
     ) -> Result<BankAccount, Error> {
-        client.post(&format!("/customers/{}/sources/{}/verify", customer_id, bank_account_id), params)
+        client.post_form(&format!("/customers/{}/sources/{}/verify", customer_id, bank_account_id), params)
     }
 }
 

--- a/stripe/src/resources/customer.rs
+++ b/stripe/src/resources/customer.rs
@@ -3,7 +3,6 @@ use error::Error;
 use ids::PaymentSourceId;
 use params::{Identifiable, List, Metadata, RangeQuery, Timestamp};
 use resources::{Address, Currency, Deleted, Discount, PaymentSource, PaymentSourceParams, Subscription};
-use serde_qs as qs;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CustomerShippingDetails {
@@ -79,7 +78,7 @@ impl Customer {
     ///
     /// For more details see https://stripe.com/docs/api#create_customer.
     pub fn create(client: &Client, params: CustomerParams) -> Result<Customer, Error> {
-        client.post("/customers", params)
+        client.post_form("/customers", params)
     }
 
     /// Retrieves the details of a customer.
@@ -97,7 +96,7 @@ impl Customer {
         customer_id: &str,
         params: CustomerParams,
     ) -> Result<Customer, Error> {
-        client.post(&format!("/customers/{}", customer_id), params)
+        client.post_form(&format!("/customers/{}", customer_id), params)
     }
 
     /// Deletes a customer.
@@ -111,7 +110,7 @@ impl Customer {
     ///
     /// For more details see https://stripe.com/docs/api#list_customers.
     pub fn list(client: &Client, params: CustomerListParams) -> Result<List<Customer>, Error> {
-        client.get(&format!("/customers?{}", qs::to_string(&params)?))
+        client.get_query("/customers", &params)
     }
 }
 

--- a/stripe/src/resources/invoices.rs
+++ b/stripe/src/resources/invoices.rs
@@ -2,7 +2,6 @@ use client::Client;
 use error::Error;
 use params::{Identifiable, List, Metadata, RangeQuery, Timestamp};
 use resources::{Currency, Discount, Plan};
-use serde_qs as qs;
 
 /// The set of parameters that can be used when creating or updating an invoice.
 ///
@@ -188,7 +187,7 @@ impl Invoice {
     ///
     /// For more details see https://stripe.com/docs/api#create_invoice.
     pub fn create(client: &Client, params: InvoiceParams) -> Result<Invoice, Error> {
-        client.post("/invoices", params)
+        client.post_form("/invoices", params)
     }
 
     /// Retrieves the details of an invoice.
@@ -207,14 +206,14 @@ impl Invoice {
     ///
     /// For more details see https://stripe.com/docs/api#upcoming_invoice
     pub fn upcoming(client: &Client, params: InvoiceUpcomingParams) -> Result<Invoice, Error> {
-        client.get(&format!("/invoices/upcoming?{}", qs::to_string(&params)?))
+        client.get_query("/invoices/upcoming", &params)
     }
 
     /// Pays an invoice.
     ///
     /// For more details see https://stripe.com/docs/api#pay_invoice.
     pub fn pay(client: &Client, invoice_id: &str) -> Result<Invoice, Error> {
-        client.post_empty(&format!("/invoices/{}/pay", invoice_id))
+        client.post(&format!("/invoices/{}/pay", invoice_id))
     }
 
     /// Updates an invoice.
@@ -225,14 +224,14 @@ impl Invoice {
         invoice_id: &str,
         params: InvoiceParams,
     ) -> Result<Invoice, Error> {
-        client.post(&format!("/invoices/{}", invoice_id), &params)
+        client.post_form(&format!("/invoices/{}", invoice_id), &params)
     }
 
     /// Lists all invoices.
     ///
     /// For more details see https://stripe.com/docs/api#list_invoices.
     pub fn list(client: &Client, params: InvoiceListParams) -> Result<List<Invoice>, Error> {
-        client.get(&format!("/invoices?{}", qs::to_string(&params)?))
+        client.get_query("/invoices", &params)
     }
 }
 
@@ -244,7 +243,7 @@ impl InvoiceLineItem {
         client: &Client,
         params: InvoiceLineItemParams,
     ) -> Result<InvoiceLineItem, Error> {
-        client.post(&format!("/invoiceitems"), &params)
+        client.post_form(&format!("/invoiceitems"), &params)
     }
 }
 

--- a/stripe/src/resources/payment_intents.rs
+++ b/stripe/src/resources/payment_intents.rs
@@ -83,7 +83,10 @@ pub enum PaymentErrorType {
     InvalidRequest,
     #[serde(rename = "rate_limit_error")]
     RateLimit,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -100,7 +103,10 @@ pub enum PaymentIntentStatus {
     RequiresCapture,
     Canceled,
     Succeeded,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 /// The resource representing a Stripe CancellationReason object.
@@ -112,7 +118,10 @@ pub enum CancellationReason {
     Duplicate,
     Fraudulent,
     RequestedByCustomer,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 /// The resource representing a Stripe CaptureMethod object.
@@ -123,7 +132,10 @@ pub enum CancellationReason {
 pub enum CaptureMethod {
     Automatic,
     Manual,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 /// The resource representing a Stripe ConfirmationMethod object.
@@ -134,7 +146,10 @@ pub enum CaptureMethod {
 pub enum ConfirmationMethod {
     Secret,
     Publishable,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -146,7 +161,10 @@ pub enum ConfirmationMethod {
 pub enum SourceActionType {
     AuthorizeWithUrl,
     UseStripeSdk,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 

--- a/stripe/src/resources/payment_intents.rs
+++ b/stripe/src/resources/payment_intents.rs
@@ -2,7 +2,6 @@ use client::Client;
 use error::Error;
 use params::{Identifiable, List, Metadata, RangeQuery, Timestamp};
 use resources::{Charge, Currency, ShippingDetails};
-use serde_qs as qs;
 
 /// The resource representing a Stripe PaymentIntent object.
 ///
@@ -328,7 +327,7 @@ impl PaymentIntent {
         client: &Client,
         params: PaymentIntentCreateParams,
     ) -> Result<PaymentIntent, Error> {
-        client.post("/payment_intents", params)
+        client.post_form("/payment_intents", params)
     }
 
     /// Retrieves the details of a payment_intent.
@@ -346,7 +345,7 @@ impl PaymentIntent {
         payment_intent_id: &str,
         params: PaymentIntentUpdateParams,
     ) -> Result<PaymentIntent, Error> {
-        client.post(&format!("/payment_intents/{}", payment_intent_id), params)
+        client.post_form(&format!("/payment_intents/{}", payment_intent_id), params)
     }
 
     /// Confirm that customer intends to pay with current or provided source. Upon confirmation, the PaymentIntent will attempt to initiate a payment.
@@ -357,7 +356,7 @@ impl PaymentIntent {
         payment_intent_id: &str,
         params: PaymentIntentConfirmParams,
     ) -> Result<PaymentIntent, Error> {
-        client.post(
+        client.post_form(
             &format!("/payment_intents/{}/confirm", payment_intent_id),
             params,
         )
@@ -371,7 +370,7 @@ impl PaymentIntent {
         payment_intent_id: &str,
         params: PaymentIntentCaptureParams,
     ) -> Result<PaymentIntent, Error> {
-        client.post(
+        client.post_form(
             &format!("/payment_intents/{}/capture", payment_intent_id),
             params,
         )
@@ -385,7 +384,7 @@ impl PaymentIntent {
         payment_intent_id: &str,
         params: PaymentIntentCancelParams,
     ) -> Result<PaymentIntent, Error> {
-        client.post(
+        client.post_form(
             &format!("/payment_intents/{}/cancel", payment_intent_id),
             params,
         )
@@ -398,6 +397,6 @@ impl PaymentIntent {
         client: &Client,
         params: PaymentIntentListParams,
     ) -> Result<List<PaymentIntent>, Error> {
-        client.get(&format!("/payment_intents?{}", qs::to_string(&params)?))
+        client.get_query("/payment_intents", &params)
     }
 }

--- a/stripe/src/resources/payment_source.rs
+++ b/stripe/src/resources/payment_source.rs
@@ -1,11 +1,37 @@
 use ids::{SourceId, TokenId};
 use resources::{Card, CardParams, Source};
 
+/// A PaymentSourceParams represents all of the supported ways that can
+/// be used to creating a new customer with a payment method or creating
+/// a payment method directly for a customer via `Customer::attach_source`.
+///
+/// Not to be confused with `SourceParams` which is used by `Source::create`
+/// to create a source that is not necessarily attached to a customer.
 #[derive(Clone, Debug)]
 pub enum PaymentSourceParams<'a> {
-    Source(SourceId),
+    /// Creates a payment method (e.g. card or bank account) from tokenized data,
+    /// using a token typically received from Stripe Elements.
     Token(TokenId),
+
+    /// Attach an existing source to an existing customer or
+    /// create a new customer from an existing source.
+    Source(SourceId),
+
+    /// Creates a `Card` payment method from the full card
+    /// information (e.g. card number, expiration, etc).
+    ///
+    /// You usually want to use `Token` received from
+    /// [Stripe Elements](https://stripe.com/docs/stripe-js)
+    /// instead.
     Card(CardParams<'a>),
+
+    // /// Creates a `BankAccount` payment method from the full account
+    // /// information (e.g. account number, expiration, etc).
+    // ///
+    // /// You usually want to use `Token` received from
+    // /// [Stripe Elements](https://stripe.com/docs/stripe-js)
+    // /// instead.
+    // TODO: BankAccount(BankAccountParams<'a>)
 }
 
 impl<'de> ::serde::Deserialize<'de> for PaymentSourceParams<'de> {
@@ -72,12 +98,17 @@ impl<'a> ::serde::Serialize for PaymentSourceParams<'a> {
     }
 }
 
+/// A PaymentSource represents a payment method _associated with a customer or charge_.
+/// This value is usually returned as a subresource on another request.
+///
+/// Not to be confused with `Source` which represents a "generic" payment method
+/// returned by the `Source::get` (which could still be a credit card, etc)
+/// but is not necessarily attached to either a customer or charge.
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "object", rename_all = "snake_case")]
 pub enum PaymentSource {
+    // TODO: Add `BankAccount(BankAccount)` variant
     Card(Card),
     Source(Source),
-
-    // FIXME: Add `BankAccount` variant after determing which struct is
-    //        the correct representation of bank accounts in this context.
 }

--- a/stripe/src/resources/payout.rs
+++ b/stripe/src/resources/payout.rs
@@ -56,7 +56,10 @@ pub enum PayoutFailureCode {
     InvalidCurrency,
     NoAccount,
     UnsupportedCard,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 /// An enum representing the possible values of a `PayOut`'s `method` field.
@@ -67,7 +70,10 @@ pub enum PayoutFailureCode {
 pub enum PayoutMethod {
     Standard,
     Instant,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 /// An enum representing the possible values of a `PayOut`'s `source_type` field.
@@ -79,7 +85,10 @@ pub enum PayoutSourceType {
     Card,
     BankAccount,
     AlipayAccount,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 /// An enum representing the possible values of a `PayOut`'s `status` field.
@@ -93,7 +102,10 @@ pub enum PayoutStatus {
     InTransit,
     Canceled,
     Failed,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -105,7 +117,10 @@ pub enum PayoutStatus {
 pub enum PayoutType {
     BankAccount,
     Card,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 

--- a/stripe/src/resources/payout.rs
+++ b/stripe/src/resources/payout.rs
@@ -2,7 +2,6 @@ use client::Client;
 use error::Error;
 use params::{Identifiable, List, Metadata, RangeQuery, Timestamp};
 use resources::Currency;
-use serde_qs as qs;
 
 /// The resource representing a Stripe payout.
 ///
@@ -171,7 +170,7 @@ impl Payout {
     ///
     /// For more details see [https://stripe.com/docs/api/payouts/create](https://stripe.com/docs/api/payouts/create).
     pub fn create(client: &Client, params: PayoutParams) -> Result<Payout, Error> {
-        client.post("/payouts", params)
+        client.post_form("/payouts", params)
     }
 
     /// Retrieves the details of a payout.
@@ -189,20 +188,20 @@ impl Payout {
         payout_id: &str,
         metadata: Option<Metadata>,
     ) -> Result<Payout, Error> {
-        client.post(&format!("/payouts/{}", payout_id), metadata)
+        client.post_form(&format!("/payouts/{}", payout_id), metadata)
     }
 
     /// List all payouts.
     ///
     /// For more details see [https://stripe.com/docs/api/payouts/list](https://stripe.com/docs/api/payouts/list).
     pub fn list(client: &Client, params: PayoutListParams) -> Result<List<Payout>, Error> {
-        client.get(&format!("/payouts?{}", qs::to_string(&params)?))
+        client.get_query("/payouts", &params)
     }
 
     /// Cancels the payout.
     ///
     /// For more details see [https://stripe.com/docs/api/payouts/cancel](https://stripe.com/docs/api/payouts/cancel).
     pub fn cancel(client: &Client, payout_id: &str) -> Result<Payout, Error> {
-        client.post_empty(&format!("/payouts/{}/cancel", payout_id))
+        client.post(&format!("/payouts/{}/cancel", payout_id))
     }
 }

--- a/stripe/src/resources/plan.rs
+++ b/stripe/src/resources/plan.rs
@@ -52,7 +52,7 @@ impl Plan {
     ///
     /// For more details see https://stripe.com/docs/api#create_plan.
     pub fn create(client: &Client, params: PlanParams) -> Result<Plan, Error> {
-        client.post("/plans", params)
+        client.post_form("/plans", params)
     }
 
     /// Retrieves the details of a plan.
@@ -66,7 +66,7 @@ impl Plan {
     ///
     /// For more details see https://stripe.com/docs/api#update_plan.
     pub fn update(client: &Client, plan_id: &str, params: PlanParams) -> Result<Plan, Error> {
-        client.post(&format!("/plans/{}", plan_id), params)
+        client.post_form(&format!("/plans/{}", plan_id), params)
     }
 
     /// Deletes a plan.

--- a/stripe/src/resources/refund.rs
+++ b/stripe/src/resources/refund.rs
@@ -39,7 +39,10 @@ pub enum RefundReason {
     Duplicate,
     Fraudulent,
     RequestedByCustomer,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -53,7 +56,10 @@ pub enum RefundStatus {
     Succeeded,
     Failed,
     Canceled,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -66,7 +72,10 @@ pub enum RefundFailureReason {
     LostOrStolenCard,
     ExpiredOrCanceledCard,
     Unknown,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 

--- a/stripe/src/resources/refund.rs
+++ b/stripe/src/resources/refund.rs
@@ -2,7 +2,6 @@ use client::Client;
 use error::Error;
 use params::{Identifiable, List, Metadata, RangeQuery, Timestamp};
 use resources::Currency;
-use serde_qs as qs;
 
 /// The resource representing a Stripe refund.
 ///
@@ -114,7 +113,7 @@ impl Refund {
     ///
     /// For more details see [https://stripe.com/docs/api/refunds/create](https://stripe.com/docs/api/refunds/create).
     pub fn create(client: &Client, params: RefundParams) -> Result<Refund, Error> {
-        client.post("/refunds", params)
+        client.post_form("/refunds", params)
     }
 
     /// Retrieves the details of a refund.
@@ -132,13 +131,13 @@ impl Refund {
         refund_id: &str,
         metadata: Option<Metadata>,
     ) -> Result<Refund, Error> {
-        client.post(&format!("/refunds/{}", refund_id), metadata)
+        client.post_form(&format!("/refunds/{}", refund_id), metadata)
     }
 
     /// List all refunds.
     ///
     /// For more details see [https://stripe.com/docs/api#list_refunds](https://stripe.com/docs/api#list_refunds).
     pub fn list(client: &Client, params: RefundListParams) -> Result<List<Refund>, Error> {
-        client.get(&format!("/refunds?{}", qs::to_string(&params)?))
+        client.get_query("/refunds", &params)
     }
 }

--- a/stripe/src/resources/source.rs
+++ b/stripe/src/resources/source.rs
@@ -228,7 +228,7 @@ pub struct Source {
 
 impl Source {
     pub fn create(client: &Client, params: SourceParams) -> Result<Source, Error> {
-        client.post("/sources", params)
+        client.post_form("/sources", params)
     }
 
     pub fn get(client: &Client, source_id: &str) -> Result<Source, Error> {
@@ -236,7 +236,7 @@ impl Source {
     }
 
     pub fn update(client: &Client, source_id: &str, params: SourceParams) -> Result<Source, Error> {
-        client.post(&format!("/source/{}", source_id), params)
+        client.post_form(&format!("/source/{}", source_id), params)
     }
 
     /// Attaches a source to a customer, does not change default Source for the Customer
@@ -250,7 +250,7 @@ impl Source {
         #[derive(Serialize)]
         struct AttachSource<'a> { source: &'a str }
         let params = AttachSource { source: source_id };
-        client.post(&format!("/customers/{}/sources", customer_id), params)
+        client.post_form(&format!("/customers/{}/sources", customer_id), params)
     }
 
     /// Detaches a source from a customer

--- a/stripe/src/resources/source.rs
+++ b/stripe/src/resources/source.rs
@@ -29,14 +29,15 @@ pub struct CodeVerification {
 ///
 /// For more details see [https://stripe.com/docs/api#source_object-code_verification-status](https://stripe.com/docs/api#source_object-code_verification-status)
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum VerificationStatus {
-    #[serde(rename="pending")]
     Pending,
-    #[serde(rename="succeeded")]
     Succeeded,
-    #[serde(rename="failed")]
     Failed,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -112,7 +113,10 @@ pub enum SourceType {
     SepaDebit,
     Sofort,
     ThreeDSecure,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -127,7 +131,10 @@ pub enum SourceStatus {
     Consumed,
     Failed,
     Pending,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -141,7 +148,10 @@ pub enum SourceFlow {
     Receiver,
     CodeVerification,
     None,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 
@@ -153,7 +163,10 @@ pub enum SourceFlow {
 pub enum SourceUsage {
     Reusable,
     SingleUse,
-    #[serde(other)]
+
+    /// A variant not yet supported by the library.
+    /// It is an error to send `Other` as part of a request.
+    #[serde(other, skip_serializing)]
     Other,
 }
 

--- a/stripe/src/resources/subscription.rs
+++ b/stripe/src/resources/subscription.rs
@@ -2,7 +2,6 @@ use client::Client;
 use error::Error;
 use params::{Identifiable, List, Metadata, Timestamp};
 use resources::{Discount, Plan};
-use serde_qs as qs;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CancelParams {
@@ -100,7 +99,7 @@ impl Subscription {
     ///
     /// For more details see https://stripe.com/docs/api#create_subscription.
     pub fn create(client: &Client, params: SubscriptionParams) -> Result<Subscription, Error> {
-        client.post("/subscriptions", params)
+        client.post_form("/subscriptions", params)
     }
 
     /// Retrieves the details of a subscription.
@@ -117,7 +116,7 @@ impl Subscription {
         subscription_id: &str,
         params: SubscriptionParams,
     ) -> Result<Subscription, Error> {
-        client.post(&format!("/subscriptions/{}", subscription_id), params)
+        client.post_form(&format!("/subscriptions/{}", subscription_id), params)
     }
 
     /// Cancels a subscription.
@@ -128,7 +127,7 @@ impl Subscription {
         subscription_id: &str,
         params: CancelParams,
     ) -> Result<Subscription, Error> {
-        client.delete(&format!("/subscriptions/{}?{}", subscription_id, qs::to_string(&params)?))
+        client.delete_query(&format!("/subscriptions/{}", subscription_id), params)
     }
 }
 


### PR DESCRIPTION
Since Stripe will not accept `"other"` as a value (where enum's are sent in a request) we can catch this error before sending it to stripe.

We also bifurcate `serde` serialization errors to clarify whether the error occurred as part of _sending a request_ or _receiving a response_.