### PR TITLE
WIP: Begin using well-typed ids in response bodies

### DIFF
--- a/stripe/src/ids.rs
+++ b/stripe/src/ids.rs
@@ -8,6 +8,11 @@ macro_rules! id {
             pub fn prefix() -> &'static str {
                 $prefix
             }
+
+            #[inline]
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
+            }
         }
 
         impl ::std::fmt::Display for $newtype_name {
@@ -54,6 +59,14 @@ macro_rules! id {
         pub enum $enum_name {$(
             $variant_name($($variant_type)*),
         )*}
+
+        impl $enum_name {
+            fn as_str(&self) -> &str {
+                match *self {$(
+                    $enum_name::$variant_name(ref id) => id.as_str(),
+                )*}
+            }
+        }
 
         impl ::std::fmt::Display for $enum_name {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {

--- a/stripe/src/resources/bank_account.rs
+++ b/stripe/src/resources/bank_account.rs
@@ -1,3 +1,4 @@
+use ids::BankAccountId;
 use params::{Identifiable, Metadata};
 use resources::Currency;
 use serde::ser::SerializeStruct;
@@ -44,7 +45,7 @@ impl<'a> ::serde::Serialize for BankAccountParams<'a> {
 /// For more details see https://stripe.com/docs/api#customer_bank_account_object.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BankAccount {
-    pub id: String,
+    pub id: BankAccountId,
     pub account_holder_name: String,
     pub account_holder_type: String, // (individual or company)
     pub bank_name: String,
@@ -60,7 +61,7 @@ pub struct BankAccount {
 
 impl Identifiable for BankAccount {
     fn id(&self) -> &str {
-        &self.id
+        self.id.as_str()
     }
 }
 

--- a/stripe/src/resources/card.rs
+++ b/stripe/src/resources/card.rs
@@ -1,3 +1,4 @@
+use ids::CardId;
 use params::{Identifiable, Metadata};
 use resources::Currency;
 use serde::ser::SerializeStruct;
@@ -33,7 +34,7 @@ impl<'a> ::serde::Serialize for CardParams<'a> {
 /// For more details see [https://stripe.com/docs/api#card_object](https://stripe.com/docs/api#card_object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Card {
-    pub id: String,
+    pub id: CardId,
     pub account: Option<String>,
     pub address_city: Option<String>,
     pub address_country: Option<String>,
@@ -149,6 +150,6 @@ pub enum TokenizationMethod {
 
 impl Identifiable for Card {
     fn id(&self) -> &str {
-        &self.id
+        self.id.as_str()
     }
 }


### PR DESCRIPTION
To anyone following the changes here, penny for your thoughts about using well-typed ids in more places (following a somewhat similar trend as switching from `String` to `enum` elsewhere).

Generally the id would be that this helps catch errors earlier when receiving client values (via`FromStr::from_str`), and when passing values from a Stripe response to a stripe request, it makes it more difficult to accidentally pass a value to an incorrect API (by requiring the correct id type as part of e.g. `Customer::get`).

On the downsides, possibly increases friction when working with databases.

