### PR TITLE
Rename client params to headers to avoid confusion with headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+# Version 0.9.0
+
+
+## Breaking Changes
+- The `stripe::Params` typed was renamed to `Headers` to avoid confusion
+  with other `FooParams` types and the `params` module.
+
+
 # Version 0.8.0 (Jan 15, 2019)
 
 ## New Features
 - Added `verify_bank_account` to `Customer` resource.
 - Added BankAccount as a variant of `PaymentSource`.
-- Add the [PaymentIntents](https://stripe.com/docs/payments/payment-intents) resources, apis and events. 
+- Add the [PaymentIntents](https://stripe.com/docs/payments/payment-intents) resources, apis and events.
 
 ## Breaking Changes
 - Minimum Rust version required is 1.31.1.

--- a/stripe/src/lib.rs
+++ b/stripe/src/lib.rs
@@ -67,8 +67,8 @@ mod ids;
 mod params;
 mod resources;
 
-pub use client::{Client, Params};
+pub use client::Client;
 pub use error::{Error, ErrorCode, ErrorType, RequestError, WebhookError};
 pub use ids::*;
-pub use params::{List, Metadata, RangeBounds, RangeQuery, Timestamp};
+pub use params::{Headers, List, Metadata, RangeBounds, RangeQuery, Timestamp};
 pub use resources::*;

--- a/stripe/src/params.rs
+++ b/stripe/src/params.rs
@@ -3,6 +3,12 @@ use error::Error;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 
+#[derive(Clone, Default)]
+pub struct Headers {
+    pub stripe_account: Option<String>,
+    pub client_id: Option<String>,
+}
+
 pub trait Identifiable {
     fn id(&self) -> &str;
 }


### PR DESCRIPTION
First of a few changes for a v0.9.

I'm breaking out each into a separate PR onto a develop branch to make them easier to review for interested citizens.