### PR TITLE
Fix bug deserializing subscriptions with metered pricing

### DIFF
--- a/src/resources/plan.rs
+++ b/src/resources/plan.rs
@@ -35,7 +35,7 @@ pub struct PlanParams<'a> {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Plan {
     pub id: String,
-    pub amount: u64,
+    pub amount: Option<u64>,
     pub created: Timestamp,
     pub currency: Currency,
     pub interval: String, // (day, week, month, year)

--- a/src/resources/subscription.rs
+++ b/src/resources/subscription.rs
@@ -64,7 +64,7 @@ pub struct SubscriptionItem {
     pub id: String,
     pub created: Timestamp,
     pub plan: Plan,
-    pub quantity: u64,
+    pub quantity: Option<u64>,
 }
 
 /// The resource representing a Stripe subscription.


### PR DESCRIPTION
Subscription plans can either have [licensed or metered usage](https://stripe.com/docs/api/plans/object#plan_object-usage_type). I ran into a few deserialization errors while using metered usage:



1. The amount field of a Plan can be null if the plan uses tiered metered pricing. (I didn't keep the actual error for this one. It was basically error deserializing null to u64.)

2. The quantity field of a SubscriptionItem does not exist if the subscription uses metered pricing. Error was:
```
Deserialize(Error("missing field `quantity`", line: 120, column: 13))
```

I don't actually use metered pricing so I'm not sure if there might be other issues. These errors just came up on some test data while I was evaluating it.