### PR TITLE
Complete invoice events

### DIFF
--- a/src/resources/event.rs
+++ b/src/resources/event.rs
@@ -87,14 +87,26 @@ pub enum EventType {
     FileCreated,
     #[serde(rename = "invoice.created")]
     InvoiceCreated,
+    #[serde(rename = "invoice.deleted")]
+    InvoiceDeleted,
+    #[serde(rename = "invoice.finalized")]
+    InvoiceFinalized,
+    #[serde(rename = "invoice.marked_uncollectible")]
+    InvoiceMarkedUncollectible,
+    #[serde(rename = "invoice.payment_action_required")]
+    InvoicePaymentActionRequired,
     #[serde(rename = "invoice.payment_failed")]
     InvoicePaymentFailed,
     #[serde(rename = "invoice.payment_succeeded")]
     InvoicePaymentSucceeded,
+    #[serde(rename = "invoice.sent")]
+    InvoiceSent,
     #[serde(rename = "invoice.updated")]
     InvoiceUpdated,
     #[serde(rename = "invoice.upcoming")]
     InvoiceUpcoming,
+    #[serde(rename = "invoice.voided")]
+    InvoiceVoided,
     #[serde(rename = "invoiceitem.created")]
     InvoiceItemCreated,
     #[serde(rename = "invoiceitem.deleted")]

--- a/src/resources/subscription.rs
+++ b/src/resources/subscription.rs
@@ -615,6 +615,18 @@ pub struct CreateSubscriptionItems {
     pub tax_rates: Option<Vec<String>>,
 }
 
+impl CreateSubscriptionItems {
+    pub fn new(plan: impl AsRef<str>) -> Self {
+        Self {
+            billing_thresholds: Default::default(),
+            metadata: Default::default(),
+            plan: plan.as_ref().to_owned(),
+            quantity: Default::default(),
+            tax_rates: Default::default(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdateSubscriptionItems {
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
* Adds missing event types for invoice events (for some reason they seem to be not present in openapi specs?)
* Add a convenience `new()` function to `CreateSubscriptionItems` (for other similar structures the `new()` function was defined, but for `CreateSubscriptionItems` it was missing)