### PR TITLE
Fix data type for `default_for_currency`.

### DIFF
--- a/src/resources/bank_account.rs
+++ b/src/resources/bank_account.rs
@@ -42,7 +42,7 @@ pub struct BankAccount {
 
     /// Whether this bank account is the default external account for its currency.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_for_currency: Option<Currency>,
+    pub default_for_currency: Option<bool>,
 
     // Always true for a deleted object
     #[serde(default)]

--- a/src/resources/card.rs
+++ b/src/resources/card.rs
@@ -83,7 +83,7 @@ pub struct Card {
 
     /// Whether this card is the default external account for its currency.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_for_currency: Option<Currency>,
+    pub default_for_currency: Option<bool>,
 
     // Always true for a deleted object
     #[serde(default)]


### PR DESCRIPTION
Thanks so much for building this.

I found an error in the type definition for the `default_for_currency` field, which appears in 2 different structs.

I realize these files were generated from the spec, but I don't have time at the moment to figure out how that works.

Here's a PR which I hope someone finds useful.