### PR TITLE
Add customer variant to event data

### DIFF
--- a/src/resources/event.rs
+++ b/src/resources/event.rs
@@ -212,6 +212,7 @@ pub enum EventObject {
     Balance(Balance),
     BankAccount(BankAccount),
     Charge(Charge),
+    Customer(Customer),
     Dispute(Dispute),
     #[serde(rename = "checkout.session")]
     CheckoutSession(CheckoutSession),


### PR DESCRIPTION
The customer variant was missing, it's used on the `customer.created` and `customer.updated` events.