### PR TITLE
CheckoutSession - add setup_intent

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -506,6 +506,7 @@ def_id!(RecipientId: String); // FIXME: This doesn't seem to be documented yet
 def_id!(RefundId, "re_");
 def_id!(ReviewId, "prv_");
 def_id!(ScheduledQueryRunId, "sqr_");
+def_id!(SetupIntentId, "seti_");
 def_id!(SkuId, "sku_");
 def_id!(SourceId, "src_");
 def_id!(SubscriptionId, "sub_");

--- a/src/resources/checkout_session.rs
+++ b/src/resources/checkout_session.rs
@@ -2,7 +2,7 @@
 // This file was automatically generated.
 // ======================================
 
-use crate::ids::CheckoutSessionId;
+use crate::ids::{CheckoutSessionId, SetupIntentId};
 use crate::params::{Expandable, Object};
 use crate::resources::{Currency, Customer, PaymentIntent, Plan, Sku, Subscription};
 use serde_derive::{Deserialize, Serialize};
@@ -63,6 +63,11 @@ pub struct CheckoutSession {
     ///
     /// card) this Checkout Session is allowed to accept.
     pub payment_method_types: Vec<String>,
+
+    /// The ID of the SetupIntent for Checkout Sessions in setup mode
+    // TODO: Make this `Expandable` once a `SetupIntent` definition is in place
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setup_intent: Option<SetupIntentId>,
 
     /// The ID of the subscription created if one or more plans were provided.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
The `setup_intent` field is essential when using Checkout sessions to capture payment information. However, currently it is simply missing from the `CheckoutSession` object.

See https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-setup_intent for reference
