### PR TITLE
Fix `List::get_next`

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -166,7 +166,7 @@ impl<T: DeserializeOwned + Send + 'static> List<T> {
     pub fn get_next(client: &Client, url: &str, last_id: &str) -> Response<List<T>> {
         if url.starts_with("/v1/") {
             // TODO: Maybe parse the URL?  Perhaps `List` should always parse its `url` field.
-            let mut url = url.trim_start_matches("/v1/").to_string();
+            let mut url = url.trim_start_matches("/v1").to_string();
             if url.contains('?') {
                 url.push_str(&format!("&starting_after={}", last_id));
             } else {


### PR DESCRIPTION
This should fix #105.

It's only a quick and dirty fix though. I feel that properly parsing the URL might be a more robust option (as the already existing TODO comment suggests).