### PR TITLE
Update `create` discriminator in code generator.

### DIFF
--- a/openapi/src/main.rs
+++ b/openapi/src/main.rs
@@ -1387,7 +1387,8 @@ fn gen_impl_requests(
 
             let doc_comment = post_request["description"].as_str().unwrap_or_default();
             if segments.len() == 1 {
-                let contains_create = doc_comment.contains("Create") || doc_comment.contains("create");
+                let contains_create =
+                    doc_comment.contains("Create") || doc_comment.contains("create");
                 let contains_adds = doc_comment.contains("Adds") || doc_comment.contains("adds");
                 if !contains_create && !contains_adds {
                     continue; // skip requests which don't appear to be `create` for now

--- a/openapi/src/main.rs
+++ b/openapi/src/main.rs
@@ -1387,7 +1387,9 @@ fn gen_impl_requests(
 
             let doc_comment = post_request["description"].as_str().unwrap_or_default();
             if segments.len() == 1 {
-                if !doc_comment.contains("Create") && !doc_comment.contains("create") {
+                let contains_create = doc_comment.contains("Create") || doc_comment.contains("create");
+                let contains_adds = doc_comment.contains("Adds") || doc_comment.contains("adds");
+                if !contains_create && !contains_adds {
                     continue; // skip requests which don't appear to be `create` for now
                 }
 

--- a/src/resources/subscription_schedule.rs
+++ b/src/resources/subscription_schedule.rs
@@ -12,6 +12,8 @@ use crate::resources::{
 use serde_derive::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "SubscriptionSchedule".
+///
+/// For more details see [https://stripe.com/docs/api/subscription_schedules/object](https://stripe.com/docs/api/subscription_schedules/object).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SubscriptionSchedule {
     /// Unique identifier for the object.


### PR DESCRIPTION
This broadens the constraints on which structs to generate for creation
related endpoints. Turns out not every endpoint's description contains
the work `[Cc]reate`.

Closes #116 