### PR TITLE
Loosen ProductId prefix constraints.

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -501,7 +501,7 @@ def_id!(
 );
 def_id!(PersonId, "person_");
 def_id!(PlanId: String); // N.B. A plan id can be user-provided so can be any arbitrary string
-def_id!(ProductId, "prod_");
+def_id!(ProductId: String);
 def_id!(RecipientId: String); // FIXME: This doesn't seem to be documented yet
 def_id!(RefundId, "re_");
 def_id!(ReviewId, "prv_");


### PR DESCRIPTION
I've tested this locally against the Stripe API. This works for custom
product IDs & works for product IDs generated by Stripe.

Closes #118