### PR TITLE
Add rustls support behind a non-default feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - cargo fmt -- --check
 
   # Check "no default features"
-  - cargo build --verbose --workspace --exclude binary_size --no-default-features
+  - cargo build --verbose --workspace --exclude binary_size --no-default-features --features default-tls
 
   # Check "full/blocking"
   - cargo build --verbose --workspace --exclude binary_size
@@ -45,3 +45,7 @@ script:
   # Check "full/async
   - cargo build --verbose --features async --workspace --exclude binary_size
   - cargo test --verbose --features async --example async_create_charge
+
+  # Check "rustls-tls"
+  - cargo build --verbose --no-default-features --features "full webhook-events blocking rustls-tls" --workspace --exclude binary_size
+  - cargo test --verbose --no-default-features --features "full webhook-events blocking rustls-tls" --workspace --exclude binary_size

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = {repository = "wyyerd/stripe-rs"}
 name = "stripe"
 
 [features]
-default = ["full", "webhook-events", "blocking"]
+default = ["full", "webhook-events", "blocking", "default-tls"]
 full = [
 #    "core",
 #    "payment-methods",
@@ -63,12 +63,16 @@ webhooks = ["webhook-endpoints", "webhook-events"]
 blocking = ["tokio/rt-core"]
 async = []
 
+default-tls = ["hyper-tls"]
+rustls-tls = ["hyper-rustls"]
+
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = { version = "0.3.1", default-features = false }
 http = "0.2.0"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-hyper-tls = "0.4.0"
+hyper-tls = { version = "0.4", optional = true }
+hyper-rustls = { version = "0.19", optional = true }
 serde = "1.0.79" # N.B. we use `serde(other)` which was introduced in `1.0.79`
 serde_derive = "1.0.79"
 serde_json = "1.0"


### PR DESCRIPTION
This commit adds support for using rustls with stripe-rs. This avoids a dependency on native OpenSSL for people who'd rather avoid that. This is useful when building a static binary as you don't need to build a statically linkable OpenSSL first.