### PR TITLE
Update non-exhaustive method lists

### DIFF
--- a/src/resources/payment_intent.rs
+++ b/src/resources/payment_intent.rs
@@ -293,6 +293,8 @@ pub enum PaymentErrorType {
 #[serde(rename_all = "snake_case")]
 pub enum PaymentIntentMethodType {
     Card,
+    Ideal,
+    SepaDebit,
 }
 
 /// The resource representing a Stripe CaptureMethod object.

--- a/src/resources/payment_intent.rs
+++ b/src/resources/payment_intent.rs
@@ -289,11 +289,17 @@ pub enum PaymentErrorType {
 //       that all of the variants are _always_ the same.
 //
 //       In that case this can be replaced with a deprecated type alias.
+/// Represents the way a `PaymentIntent` needs to be fulfilled. 
 #[derive(Deserialize, Serialize, PartialEq, Debug, Clone, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentIntentMethodType {
+    /// This `PaymentIntent` needs to be fulfilled through credit card payment.
     Card,
+    /// This `PaymentIntent` needs to be fulfilled through an
+    /// [iDeal](https://stripe.com/docs/payments/ideal) payment.
     Ideal,
+    /// This `PaymentIntent` needs to be fulfilled through a
+    /// [Sepa Direct Debit](https://stripe.com/docs/payments/sepa-debit) payment.
     SepaDebit,
 }
 

--- a/src/resources/payment_method.rs
+++ b/src/resources/payment_method.rs
@@ -414,15 +414,24 @@ impl<'a> UpdatePaymentMethod<'a> {
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum PaymentMethodType {
+    /// This `PaymentMethod` must be fulfilled through credit card payment.
     Card,
-    CardPresent,
+    Fpx,
+    /// This `PaymentMethod` must be fulfilled through
+    /// [iDeal](https://stripe.com/docs/payments/ideal).
+    Ideal,
+    /// This `PaymentMethod` must be fulfilled through
+    /// [Sepa Direct Debit](https://stripe.com/docs/payments/sepa-debit).
+    SepaDebit,
 }
 
 impl PaymentMethodType {
     pub fn as_str(self) -> &'static str {
         match self {
-            PaymentMethodType::Card => "card",
-            PaymentMethodType::CardPresent => "card_present",
+            Self::Card => "card",
+            Self::Fpx => "fpx",
+            Self::Ideal => "ideal",
+            Self::SepaDebit => "sepa_debit",
         }
     }
 }


### PR DESCRIPTION
Some payment method enums exported by stripe-rs are non exhaustive in their current state. This pull request adds the missing variants to the enums that were not exhaustive. The `PaymentMethodType` enum contains a variant called `CardPresent`, but according to the [documentation](https://stripe.com/docs/api/payment_methods/object) provided by stripe, this is not a valid variant. I have removed this variant. I have also added documentation to show what each of the variants mean with a link to stripes documentation.