### PR TITLE
Support feature hyper-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ events = []
 webhooks = ["webhook-endpoints", "webhook-events"]
 
 # hyper_tls or hyper_rustls
-nativetls = ["hyper_tls"]
-rustls = ["hyper_rustls"]
+nativetls = ["hyper-tls"]
+rustls = ["hyper-rustls"]
 
 # Enable the blocking client
 blocking = ["tokio/rt-core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = {repository = "wyyerd/stripe-rs"}
 name = "stripe"
 
 [features]
-default = ["full", "webhook-events", "blocking", "hyper_tls"]
+default = ["full", "webhook-events", "blocking", "nativetls"]
 full = [
 #    "core",
 #    "payment-methods",
@@ -60,8 +60,8 @@ events = []
 webhooks = ["webhook-endpoints", "webhook-events"]
 
 # hyper_tls or hyper_rustls
-hyper_tls = ["hyper_tls"]
-hyper_rustls = ["hyper_rustls"]
+nativetls = ["hyper_tls"]
+rustls = ["hyper_rustls"]
 
 # Enable the blocking client
 blocking = ["tokio/rt-core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ travis-ci = {repository = "wyyerd/stripe-rs"}
 name = "stripe"
 
 [features]
-default = ["full", "webhook-events", "blocking"]
+default = ["full", "webhook-events", "blocking", "hyper_tls"]
 full = [
 #    "core",
 #    "payment-methods",
@@ -59,6 +59,10 @@ events = []
 # Deprecated. Use either `webhook-events` or `webhook-endpoints` instead.
 webhooks = ["webhook-endpoints", "webhook-events"]
 
+# hyper_tls or hyper_rustls
+hyper_tls = ["hyper_tls"]
+hyper_rustls = ["hyper_rustls"]
+
 # Enable the blocking client
 blocking = ["tokio/rt-core"]
 async = []
@@ -68,7 +72,6 @@ chrono = { version = "0.4", features = ["serde"] }
 futures-util = { version = "0.3.1", default-features = false }
 http = "0.2.0"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
-hyper-tls = "0.4.0"
 serde = "1.0.79" # N.B. we use `serde(other)` which was introduced in `1.0.79`
 serde_derive = "1.0.79"
 serde_json = "1.0"
@@ -79,6 +82,10 @@ tokio = { version = "0.2.0", default-features = false, features = ["tcp", "time"
 # Webhook support
 hmac = { version = "0.6", optional = true }
 sha2 = { version = "0.7", optional = true }
+
+# Native Vs Rustls TLS
+hyper-tls = { version = "0.4.0", optional = true }
+hyper-rustls = { version = "0.20", optional = true }
 
 [[example]]
 name = "async_create_charge"

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -8,11 +8,11 @@ use serde::de::DeserializeOwned;
 use std::future::Future;
 use std::pin::Pin;
 
-#[cfg(feature = "hyper_tls")]
+#[cfg(feature = "nativetls")]
 type HttpClient =
     hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>, hyper::Body>;
 
-#[cfg(feature = "hyper_rustls")]
+#[cfg(feature = "rustls")]
 type HttpClient =
     hyper::Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>, hyper::Body>;
 
@@ -49,9 +49,9 @@ impl Client {
     pub fn from_url(scheme_host: impl Into<String>, secret_key: impl Into<String>) -> Client {
         let url = scheme_host.into();
         let host = if url.ends_with('/') { format!("{}v1", url) } else { format!("{}/v1", url) };
-        #[cfg(feature = "hyper_tls")]
+        #[cfg(feature = "nativetls")]
         let https = hyper_tls::HttpsConnector::new();
-        #[cfg(feature = "hyper_rustls")]
+        #[cfg(feature = "rustls")]
         let https = hyper_rustls::HttpsConnector::new();
         let client = hyper::Client::builder().build(https);
         let mut headers = Headers::default();


### PR DESCRIPTION
For cross complied environments and environments that do not have native TLS support.

Allow feature selection to use hyper-rustls.

This is my quick approach to adding support to switch between TLS providers.