### PR TITLE
Add idempotency support to post

### DIFF
--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1,3 +1,4 @@
+use crate::client::Options;
 use crate::client::r#async::Client as AsyncClient;
 use crate::error::Error;
 use crate::params::Headers;
@@ -99,6 +100,16 @@ impl Client {
     /// Make a `POST` http request with just a path
     pub fn post<T: DeserializeOwned + Send + 'static>(&self, path: &str) -> Response<T> {
         self.send_blocking(self.inner.post(path))
+    }
+
+    /// Make a 'POST' http request with urlencoded body and options
+    pub fn post_form_options<T: DeserializeOwned + Send + 'static, F: serde::Serialize>(
+        &self,
+        path: &str,
+        form: F,
+        options: Options,
+    ) -> Response<T> {
+        self.send_blocking(self.inner.post_form_options(path, form, options))
     }
 
     /// Make a `POST` http request with urlencoded body

--- a/src/error.rs
+++ b/src/error.rs
@@ -103,6 +103,8 @@ impl From<std::io::Error> for Error {
 
 #[derive(Debug)]
 pub enum HttpError {
+    // An error parsing HTTP data
+    Http(http::Error),
     /// An error handling HTTP streams.
     Stream(hyper::Error),
     /// The request timed out.
@@ -112,6 +114,7 @@ pub enum HttpError {
 impl std::fmt::Display for HttpError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
+            HttpError::Http(ref err) => err.fmt(f),
             HttpError::Stream(ref err) => err.fmt(f),
             HttpError::Timeout => f.write_str(std::error::Error::description(self)),
         }
@@ -121,6 +124,7 @@ impl std::fmt::Display for HttpError {
 impl std::error::Error for HttpError {
     fn description(&self) -> &str {
         match *self {
+            HttpError::Http(ref err) => err.description(),
             HttpError::Stream(ref err) => err.description(),
             HttpError::Timeout => "request timed out",
         }
@@ -128,6 +132,7 @@ impl std::error::Error for HttpError {
 
     fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
+            HttpError::Http(ref err) => Some(err),
             HttpError::Stream(ref err) => Some(err),
             HttpError::Timeout => None,
         }
@@ -146,6 +151,8 @@ pub enum ErrorType {
     Connection,
     #[serde(rename = "authentication_error")]
     Authentication,
+    #[serde(rename = "idempotency_error")]
+    Idempotency,
     #[serde(rename = "card_error")]
     Card,
     #[serde(rename = "invalid_request_error")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,12 @@ mod client {
     pub mod r#async;
     #[cfg(all(feature = "blocking", not(feature = "async")))]
     pub mod blocking;
+
+    /// Options to be used when making a request
+    #[derive(Clone, Debug, Default)]
+    pub struct Options {
+        pub idempotency_key: Option<String>,
+    }
 }
 
 // Re-export `pub mod async` to be backward-compatible with 0.11.x
@@ -85,6 +91,7 @@ pub use crate::params::{
     Expandable, Headers, IdOrCreate, List, Metadata, Object, RangeBounds, RangeQuery, Timestamp,
 };
 pub use crate::resources::*;
+pub use crate::client::Options;
 
 #[cfg(all(feature = "blocking", not(feature = "async")))]
 mod config {


### PR DESCRIPTION
Hey!

I need idempotency support [1], and I hacked this together. I manually tested the `post_form_options` and the idempotency works. Unsure of what you all think about placing `Options` where it is, naming, doc-comments, etc. Also, this should/could be added to the other functions like `post`, `delete`, `delete_query`, etc.

It appears that Stripe clients use the model of having another method that just allows for options to be passed in, e.g. [javadoc](https://stripe.dev/stripe-java/com/stripe/model/Subscription.html). I think this model works, especially given that it is backwards compatible.

Thanks!

[1] https://stripe.com/docs/api/idempotent_requests 