### PR TITLE
Fix always-failing `Invoice::upcoming(...)`

### DIFF
--- a/openapi/src/main.rs
+++ b/openapi/src/main.rs
@@ -316,6 +316,9 @@ fn gen_impl_object(meta: &Metadata, object: &str) -> String {
         if let Some(doc) = schema["properties"]["id"]["description"].as_str() {
             print_doc_comment(&mut out, doc, 1);
         }
+        if id_type == "InvoiceId" {
+            out.push_str("    #[serde(default = \"InvoiceId::empty\")]");
+        }
         out.push_str("    pub id: ");
         out.push_str(&id_type);
         out.push_str(",\n");

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -528,6 +528,12 @@ def_id!(TransferId, "tr_");
 def_id!(TransferReversalId, "trr_");
 def_id!(WebhookEndpointId, "we_");
 
+impl InvoiceId {
+    pub(crate) fn empty() -> Self {
+        Self("".into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/resources/invoice.rs
+++ b/src/resources/invoice.rs
@@ -17,6 +17,7 @@ use serde_derive::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Invoice {
     /// Unique identifier for the object.
+    #[serde(default = "InvoiceId::empty")]
     pub id: InvoiceId,
 
     /// The country of the business associated with this invoice, most often the business creating the invoice.


### PR DESCRIPTION
`Invoice::upcoming(...)` would always fail. The API call returns an
invoice that doesn't actually exist, and because it doesn't exist, it
doesn't have an `"id"` field in the response.

> Note that when you are viewing an upcoming invoice, you are simply
> viewing a preview – the invoice has not yet been created. As such, the
> upcoming invoice will not show up in invoice listing calls, and you
> cannot use the API to pay or edit the invoice. If you want to change the
> amount that your customer will be billed, you can add, remove, or update
> pending invoice items, or update the customer’s discount.

The lack of an `"id"` field causes the parsing of an `Invoice` to fail.

We can't do `struct Invoice { id: Option<InvoiceId> }` because the
`Object` trait expects the ID of the object to not be an option.

It seems like the least terrible option is to set `#[serde(default)]` on
the ID field and provide an empty string as an ID. While this isn't
great, it seems like the best of the bad options.