### PR TITLE
Add method to detach a payment method

### DIFF
--- a/src/resources/payment_method.rs
+++ b/src/resources/payment_method.rs
@@ -458,6 +458,7 @@ pub enum WalletDetailsType {
     Masterpass,
     SamsungPay,
     VisaCheckout,
+    Link,
 }
 
 impl WalletDetailsType {
@@ -469,6 +470,7 @@ impl WalletDetailsType {
             WalletDetailsType::Masterpass => "masterpass",
             WalletDetailsType::SamsungPay => "samsung_pay",
             WalletDetailsType::VisaCheckout => "visa_checkout",
+            WalletDetailsType::Link => "link",
         }
     }
 }

--- a/src/resources/payment_method_ext.rs
+++ b/src/resources/payment_method_ext.rs
@@ -22,4 +22,14 @@ impl PaymentMethod {
     ) -> Response<PaymentMethod> {
         client.post_form(&format!("/payment_methods/{}/attach", payment_method_id), params)
     }
+    
+    /// Detach a payment method from its customer
+    ///
+    /// For more details see [https://stripe.com/docs/api/payment_methods/detach](https://stripe.com/docs/api/payment_methods/detach).
+    pub fn detach(
+        client: &Client,
+        payment_method_id: &PaymentMethodId,
+    ) -> Response<PaymentMethod> {
+        client.post(&format!("/payment_methods/{}/detach", payment_method_id))
+    }
 }


### PR DESCRIPTION
Stripe allows you to detach a payment method from a customer, but stripe-rs does not expose this method. This pull request adds this API.