### PR TITLE
Added application id to Application resource (Stripe Connect)

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -446,6 +446,7 @@ impl std::error::Error for ParseIdError {
 
 def_id!(AccountId, "acct_");
 def_id!(AlipayAccountId, "aliacc_");
+def_id!(ApplicationId, "ca_");
 def_id!(ApplicationFeeId, "fee_");
 def_id!(ApplicationFeeRefundId, "fr_");
 def_id!(BalanceTransactionId, "txn_");

--- a/src/resources/application.rs
+++ b/src/resources/application.rs
@@ -4,18 +4,24 @@
 
 use crate::params::Object;
 use serde_derive::{Deserialize, Serialize};
+use crate::ids::{ApplicationId};
 
 /// The resource representing a Stripe "Application".
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Application {
+    /// Unique identifier for the object.
+    pub id: ApplicationId,
+
     /// The name of the application.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 impl Object for Application {
-    type Id = ();
-    fn id(&self) -> Self::Id {}
+    type Id = ApplicationId;
+    fn id(&self) -> Self::Id {
+        self.id.clone()
+    }
     fn object(&self) -> &'static str {
         "application"
     }


### PR DESCRIPTION
Application resource was missing the id field ("ca_xxxxxxx") and therefore was bugged when using PaymentIntent (for instance) with Stripe Connect.

Cf. https://stripe.com/docs/api/payment_intents/object#payment_intent_object-application.