### PR TITLE
Add `SubscriptionSchedule::cancel` and `::release`

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -104,6 +104,8 @@ mod subscription_item;
 #[cfg(feature = "billing")]
 mod subscription_schedule;
 #[cfg(feature = "billing")]
+mod subscription_schedule_ext;
+#[cfg(feature = "billing")]
 mod tax_id;
 #[cfg(feature = "billing")]
 mod tax_rate;
@@ -131,6 +133,8 @@ pub use self::subscription_ext::*;
 pub use self::subscription_item::*;
 #[cfg(feature = "billing")]
 pub use self::subscription_schedule::*;
+#[cfg(feature = "billing")]
+pub use self::subscription_schedule_ext::*;
 #[cfg(feature = "billing")]
 pub use self::tax_id::*;
 #[cfg(feature = "billing")]

--- a/src/resources/subscription_schedule_ext.rs
+++ b/src/resources/subscription_schedule_ext.rs
@@ -1,0 +1,60 @@
+use crate::config::{Client, Response};
+use crate::ids::SubscriptionScheduleId;
+use crate::resources::SubscriptionSchedule;
+use serde_derive::Serialize;
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CancelSubscriptionSchedule {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invoice_now: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prorate: Option<bool>,
+}
+
+impl CancelSubscriptionSchedule {
+    pub fn new() -> CancelSubscriptionSchedule {
+        CancelSubscriptionSchedule::default()
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct ReleaseSubscriptionSchedule {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preserve_cancel_date: Option<bool>,
+}
+
+impl ReleaseSubscriptionSchedule {
+    pub fn new() -> ReleaseSubscriptionSchedule {
+        ReleaseSubscriptionSchedule::default()
+    }
+}
+
+impl SubscriptionSchedule {
+    /// Cancels a subscription schedule.
+    ///
+    /// For more details see https://stripe.com/docs/api/subscription_schedules/cancel
+    pub fn cancel(
+        client: &Client,
+        subscription_schedule_id: &SubscriptionScheduleId,
+        params: CancelSubscriptionSchedule,
+    ) -> Response<SubscriptionSchedule> {
+        client.post_form(
+            &format!("/subscription_schedules/{}/cancel", subscription_schedule_id),
+            params,
+        )
+    }
+
+    /// Releases a subscription schedule.
+    ///
+    /// For more details see https://stripe.com/docs/api/subscription_schedules/release
+    pub fn release(
+        client: &Client,
+        subscription_schedule_id: &SubscriptionScheduleId,
+        params: ReleaseSubscriptionSchedule,
+    ) -> Response<SubscriptionSchedule> {
+        client.post_form(
+            &format!("/subscription_schedules/{}/release", subscription_schedule_id),
+            params,
+        )
+    }
+}


### PR DESCRIPTION
Add the required methods to [cancel] or [release] a subscription
schedule.

[cancel]: https://stripe.com/docs/api/subscription_schedules/cancel
[release]: https://stripe.com/docs/api/subscription_schedules/release