### PR TITLE
updating Subscription::cancel()

### DIFF
--- a/src/resources/subscription_ext.rs
+++ b/src/resources/subscription_ext.rs
@@ -3,18 +3,6 @@ use crate::ids::SubscriptionId;
 use crate::resources::{CreateSubscriptionItems, Subscription};
 use serde_derive::Serialize;
 
-#[derive(Clone, Debug, Default, Serialize)]
-pub struct CancelSubscription {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub at_period_end: Option<bool>,
-}
-
-impl CancelSubscription {
-    pub fn new() -> CancelSubscription {
-        CancelSubscription { at_period_end: None }
-    }
-}
-
 impl Subscription {
     /// Cancels a subscription.
     ///
@@ -22,9 +10,8 @@ impl Subscription {
     pub fn cancel(
         client: &Client,
         subscription_id: &SubscriptionId,
-        params: CancelSubscription,
     ) -> Response<Subscription> {
-        client.delete_query(&format!("/subscriptions/{}", subscription_id), params)
+        client.delete(&format!("/subscriptions/{}", subscription_id))
     }
 }
 


### PR DESCRIPTION
as per https://stripe.com/docs/upgrades#2018-08-23:

- You can no longer set `at_period_end` in the subscription `DELETE` endpoints. The `DELETE` endpoint is reserved for immediate canceling going forward. Use `cancel_at_period_end` on the subscription update endpoints instead.