### PR TITLE
Integrated generated code for /v1/account_links

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -152,6 +152,8 @@ pub use self::tax_rate::*;
 #[cfg(feature = "connect")]
 mod account;
 #[cfg(feature = "connect")]
+mod account_link;
+#[cfg(feature = "connect")]
 mod application;
 #[cfg(feature = "connect")]
 mod application_fee;
@@ -171,6 +173,8 @@ mod transfer;
 mod transfer_reversal;
 #[cfg(feature = "connect")]
 pub use self::account::*;
+#[cfg(feature = "connect")]
+pub use self::account_link::*;
 #[cfg(feature = "connect")]
 pub use self::application::*;
 #[cfg(feature = "connect")]

--- a/src/resources/account_link.rs
+++ b/src/resources/account_link.rs
@@ -1,0 +1,144 @@
+// ======================================
+// This file was automatically generated.
+// ======================================
+
+use crate::config::{Client, Response};
+use crate::ids::AccountId;
+use crate::params::{Expand, Object, Timestamp};
+use serde_derive::{Deserialize, Serialize};
+
+/// The resource representing a Stripe "AccountLink".
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AccountLink {
+    /// Time at which the object was created.
+    ///
+    /// Measured in seconds since the Unix epoch.
+    pub created: Timestamp,
+
+    /// The timestamp at which this account link will expire.
+    pub expires_at: Timestamp,
+
+    /// The URL for the account link.
+    pub url: String,
+}
+
+impl AccountLink {
+    /// Creates an AccountLink object that returns a single-use Stripe URL that the user can redirect their user to in order to take them through the Connect Onboarding flow.
+    pub fn create(client: &Client, params: CreateAccountLink<'_>) -> Response<AccountLink> {
+        client.post_form("/account_links", &params)
+    }
+}
+
+impl Object for AccountLink {
+    type Id = ();
+    fn id(&self) -> Self::Id {}
+    fn object(&self) -> &'static str {
+        "account_link"
+    }
+}
+
+/// The parameters for `AccountLink::create`.
+#[derive(Clone, Debug, Serialize)]
+pub struct CreateAccountLink<'a> {
+    /// The identifier of the account to create an account link for.
+    pub account: AccountId,
+
+    /// Which information the platform needs to collect from the user.
+    ///
+    /// One of `currently_due` or `eventually_due`.
+    /// Default is `currently_due`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collect: Option<AccountLinkCollect>,
+
+    /// Specifies which fields in the response should be expanded.
+    #[serde(skip_serializing_if = "Expand::is_empty")]
+    pub expand: &'a [&'a str],
+
+    /// The URL that the user will be redirected to if the account link is no longer valid.
+    pub failure_url: &'a str,
+
+    /// The URL that the user will be redirected to upon leaving or completing the linked flow successfully.
+    pub success_url: &'a str,
+
+    /// The type of account link the user is requesting.
+    ///
+    /// Possible values are `custom_account_verification` or `custom_account_update`.
+    #[serde(rename = "type")]
+    pub type_: AccountLinkType,
+}
+
+impl<'a> CreateAccountLink<'a> {
+    pub fn new(
+        account: AccountId,
+        failure_url: &'a str,
+        success_url: &'a str,
+        type_: AccountLinkType,
+    ) -> Self {
+        CreateAccountLink {
+            account,
+            collect: Default::default(),
+            expand: Default::default(),
+            failure_url,
+            success_url,
+            type_,
+        }
+    }
+}
+
+/// An enum representing the possible values of an `CreateAccountLink`'s `collect` field.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountLinkCollect {
+    CurrentlyDue,
+    EventuallyDue,
+}
+
+impl AccountLinkCollect {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AccountLinkCollect::CurrentlyDue => "currently_due",
+            AccountLinkCollect::EventuallyDue => "eventually_due",
+        }
+    }
+}
+
+impl AsRef<str> for AccountLinkCollect {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for AccountLinkCollect {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+/// An enum representing the possible values of an `CreateAccountLink`'s `type_` field.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountLinkType {
+    AccountUpdate,
+    AccountOnboarding,
+}
+
+impl AccountLinkType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AccountLinkType::AccountUpdate => "account_update",
+            AccountLinkType::AccountOnboarding => "account_onboarding",
+        }
+    }
+}
+
+impl AsRef<str> for AccountLinkType {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for AccountLinkType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}


### PR DESCRIPTION
Simply includes the generated code and adds the `mod` and `pub use` statements in resources.rs. One modification from the generated code was made for API compliance: the generated `AccountLinkType` enum had the options `CustomAccountUpdate` and `CustomAccountVerification`, but I changed it to `AccountUpdate` and `AccountOnboarding` to match the API documented [here](https://stripe.com/docs/api/account_links/create). The resulting functionality was tested a decent amount and seems to work properly.