### PR TITLE
Draft: Async std runtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,17 +35,25 @@ script:
   - rustup component add rustfmt
   - cargo fmt -- --check
 
-  # Check "no default features"
-  - cargo build --verbose --workspace --exclude binary_size --no-default-features --features default-tls
+  # Check minimal features "runtime-blocking"
+  - cargo build --verbose --workspace --exclude binary_size --no-default-features --features runtime-blocking
 
-  # Check "full/blocking"
-  - cargo build --verbose --workspace --exclude binary_size
-  - cargo test --verbose --workspace --exclude binary_size
+  # Check "runtime-blocking"
+  - cargo build --verbose --workspace --exclude binary_size --no-default-features --features "runtime-blocking full webhook-events"
+  - cargo test --verbose --workspace --exclude binary_size --no-default-features --features "runtime-blocking full webhook-events"
 
-  # Check "full/async
-  - cargo build --verbose --features async --workspace --exclude binary_size
-  - cargo test --verbose --features async --example async_create_charge
+  # Check "runtime-blocking-rustls"
+  - cargo build --verbose --workspace --exclude binary_size --no-default-features --features "runtime-blocking-rustls full webhook-events"
+  - cargo test --verbose --workspace --exclude binary_size --no-default-features --features "runtime-blocking-rustls full webhook-events"
 
-  # Check "rustls-tls"
-  - cargo build --verbose --no-default-features --features "full webhook-events blocking rustls-tls" --workspace --exclude binary_size
-  - cargo test --verbose --no-default-features --features "full webhook-events blocking rustls-tls" --workspace --exclude binary_size
+  # Check "runtime-tokio-hyper"
+  - cargo build --verbose --workspace --exclude binary_size --features runtime-tokio-hyper
+  - cargo test --verbose --example async_create_charge --features runtime-tokio-hyper
+
+  # Check "runtime-tokio-hyper-rustls"
+  - cargo build --verbose --workspace --exclude binary_size --features runtime-tokio-hyper-rustls
+  - cargo test --verbose --example async_create_charge --features runtime-tokio-hyper-rustls
+
+  # Check "runtime-async-std-surf"
+  - cargo build --verbose --workspace --exclude binary_size --features runtime-async-std-surf
+  - cargo test --verbose --example async_create_charge --features runtime-async-std-surf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ travis-ci = {repository = "wyyerd/stripe-rs"}
 name = "stripe"
 
 [features]
-default = ["full", "webhook-events", "default-tls"]
+default = ["full", "webhook-events"]
 full = [
 #    "core",
 #    "payment-methods",
@@ -58,17 +58,19 @@ webhook-endpoints = []
 webhook-events = ["events", "hmac", "sha2"]
 events = []
 
-# Enable the blocking client
-blocking = ["tokio/rt-core"]
-
-default-tls = ["hyper-tls"]
-rustls-tls = ["hyper-rustls"]
+# runtimes
+runtime-tokio-hyper = ["tokio", "hyper", "hyper-tls"]
+runtime-tokio-hyper-rustls = ["tokio", "hyper", "hyper-rustls"]
+runtime-blocking = ["tokio", "tokio/rt-core", "hyper", "hyper-tls"]
+runtime-blocking-rustls = ["tokio", "tokio/rt-core", "hyper", "hyper-rustls"]
+runtime-async-std-surf = ["async-std", "surf"]
 
 [dependencies]
+async-std = { version = "1.7", optional = true }
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"
-hyper = { version = "0.13", default-features = false, features = ["tcp"] }
+hyper = { version = "0.13", default-features = false, features = ["tcp"], optional = true }
 hyper-tls = { version = "0.4", optional = true }
 hyper-rustls = { version = "0.20", optional = true }
 serde = "1.0.79" # N.B. we use `serde(other)` which was introduced in `1.0.79`
@@ -76,7 +78,8 @@ serde_derive = "1.0.79"
 serde_json = "1.0"
 serde_qs = "0.5"
 smol_str = "0.1"
-tokio = { version = "0.2", default-features = false, features = ["tcp", "time"] }
+surf = { version = "2.1.0", optional = true } 
+tokio = { version = "0.2", default-features = false, features = ["tcp", "time"], optional = true } 
 
 # Webhook support
 hmac = { version = "0.7", optional = true }
@@ -88,19 +91,19 @@ name = "async_create_charge"
 
 [[example]]
 name = "create_charge"
-required-features = ["blocking"]
+required-features = ["runtime-blocking"]
 
 [[example]]
 name = "create_customer"
-required-features = ["blocking"]
+required-features = ["runtime-blocking"]
 
 [[example]]
 name = "create_customer_with_source"
-required-features = ["blocking"]
+required-features = ["runtime-blocking"]
 
 [[example]]
 name = "list_customers"
-required-features = ["blocking"]
+required-features = ["runtime-blocking"]
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/bench/binary_size/Cargo.toml
+++ b/bench/binary_size/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [features]
 full = ["stripe-rust/full", "stripe-rust/webhook-events"]
-blocking = ["stripe-rust/blocking"]
+runtime-blocking = ["stripe-rust/runtime-blocking"]
 checkout = ["stripe-rust/checkout"]
 billing = ["stripe-rust/billing"]
 connect = ["stripe-rust/connect"]
@@ -19,4 +19,4 @@ sigma = ["stripe-rust/sigma"]
 webhook-endpoints = ["stripe-rust/webhook-endpoints"]
 
 [dependencies]
-stripe-rust = { path = "../../", default-features = false, features = ["default-tls"] }
+stripe-rust = { path = "../../", default-features = false }

--- a/bench/binary_size/src/main.rs
+++ b/bench/binary_size/src/main.rs
@@ -3,13 +3,13 @@ fn main() {
     let secret_key = std::env::var("STRIPE_SECRET_KEY").expect("Missing STRIPE_SECRET_KEY in env");
     let client = stripe::Client::new(secret_key);
 
-    #[cfg(feature = "blocking")]
+    #[cfg(feature = "runtime-blocking")]
     {
         create_charge(&client);
         create_customer(&client);
     }
 
-    #[cfg(not(feature = "blocking"))]
+    #[cfg(not(feature = "runtime-blocking"))]
     {
         let mut fut = Box::pin(async {
             create_charge(&client).await;
@@ -36,7 +36,7 @@ fn main() {
     // TODO: Use other apis
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(feature = "runtime-blocking")]
 fn create_charge(client: &stripe::Client) {
     // Define a card to charge
     let card = "card_189g322eZvKYlo2CeoPw2sdy".parse().expect("expected card to be valid");
@@ -53,7 +53,7 @@ fn create_charge(client: &stripe::Client) {
     println!("{:?}", charge);
 }
 
-#[cfg(feature = "blocking")]
+#[cfg(feature = "runtime-blocking")]
 fn create_customer(client: &stripe::Client) {
     // Define the customer
     let token = "tok_189g322eZvKYlo2CeoPw2sdy".parse().expect("expected token to be valid");
@@ -68,7 +68,7 @@ fn create_customer(client: &stripe::Client) {
     println!("{:?}", customer);
 }
 
-#[cfg(not(feature = "blocking"))]
+#[cfg(not(feature = "runtime-blocking"))]
 async fn create_charge(client: &stripe::Client) {
     // Define a card to charge
     let card = "card_189g322eZvKYlo2CeoPw2sdy".parse().expect("expected card to be valid");
@@ -85,7 +85,7 @@ async fn create_charge(client: &stripe::Client) {
     println!("{:?}", charge);
 }
 
-#[cfg(not(feature = "blocking"))]
+#[cfg(not(feature = "runtime-blocking"))]
 async fn create_customer(client: &stripe::Client) {
     // Define the customer
     let token = "tok_189g322eZvKYlo2CeoPw2sdy".parse().expect("expected token to be valid");

--- a/examples/async_create_charge.rs
+++ b/examples/async_create_charge.rs
@@ -2,7 +2,7 @@
 async fn main() {
     // Create a new client
     let secret_key = std::env::var("STRIPE_SECRET_KEY").expect("Missing STRIPE_SECRET_KEY in env");
-    let client = stripe::r#async::Client::new(secret_key);
+    let client = stripe::Client::new(secret_key);
 
     // Define a card to charge
     let card = "card_189g322eZvKYlo2CeoPw2sdy".parse().expect("expected card to be valid");

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1,4 +1,4 @@
-use crate::client::r#async::Client as AsyncClient;
+use crate::client::tokio::Client as AsyncClient;
 use crate::error::Error;
 use crate::params::Headers;
 use serde::de::DeserializeOwned;
@@ -112,7 +112,7 @@ impl Client {
 
     fn send_blocking<T: DeserializeOwned + Send + 'static>(
         &self,
-        request: super::r#async::Response<T>,
+        request: super::tokio::Response<T>,
     ) -> Response<T> {
         match self.runtime.borrow_mut().block_on(async {
             // N.B. The `tokio::time::timeout` must be called from within a running async
@@ -120,7 +120,7 @@ impl Client {
             tokio::time::timeout(DEFAULT_TIMEOUT, request).await
         }) {
             Ok(finished) => finished,
-            Err(_) => Err(Error::timeout()),
+            Err(_) => Err(Error::Timeout),
         }
     }
 }

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -1,0 +1,257 @@
+use crate::error::{Error, ErrorResponse, RequestError};
+use crate::params::{AppInfo, Headers};
+use crate::resources::ApiVersion;
+use futures_util::future;
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+use http::request::Builder as RequestBuilder;
+use serde::de::DeserializeOwned;
+use std::future::Future;
+use std::pin::Pin;
+
+#[cfg(feature = "hyper-rustls")]
+use hyper_rustls::HttpsConnector;
+#[cfg(feature = "hyper-tls")]
+use hyper_tls::HttpsConnector;
+#[cfg(all(feature = "hyper-tls", feature = "hyper-rustls"))]
+compile_error!("You must enable only one TLS implementation");
+
+type HttpClient = hyper::Client<HttpsConnector<hyper::client::HttpConnector>, hyper::Body>;
+
+pub type Response<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send>>;
+
+#[allow(dead_code)]
+#[inline(always)]
+pub(crate) fn ok<T: Send + 'static>(ok: T) -> Response<T> {
+    Box::pin(future::ready(Ok(ok)))
+}
+
+#[allow(dead_code)]
+#[inline(always)]
+pub(crate) fn err<T: Send + 'static>(err: Error) -> Response<T> {
+    Box::pin(future::ready(Err(err)))
+}
+
+#[derive(Clone)]
+pub struct Client {
+    host: String,
+    client: HttpClient,
+    secret_key: String,
+    headers: Headers,
+    app_info: Option<AppInfo>,
+}
+
+impl Client {
+    /// Creates a new client pointed to `https://api.stripe.com/`
+    pub fn new(secret_key: impl Into<String>) -> Client {
+        Client::from_url("https://api.stripe.com/", secret_key)
+    }
+
+    /// Creates a new client posted to a custom `scheme://host/`
+    pub fn from_url(scheme_host: impl Into<String>, secret_key: impl Into<String>) -> Client {
+        let url = scheme_host.into();
+        let host = if url.ends_with('/') { format!("{}v1", url) } else { format!("{}/v1", url) };
+        let https = HttpsConnector::new();
+        let client = hyper::Client::builder().build(https);
+        let mut headers = Headers::default();
+        // TODO: Automatically determine the latest supported api version in codegen?
+        headers.stripe_version = Some(ApiVersion::V2019_09_09);
+        Client {
+            host,
+            client,
+            secret_key: secret_key.into(),
+            headers,
+            app_info: Some(AppInfo::default()),
+        }
+    }
+
+    /// Clones a new client with different headers.
+    ///
+    /// This is the recommended way to send requests for many different Stripe accounts
+    /// or with different Meta, Extra, and Expand headers while using the same secret key.
+    pub fn with_headers(&self, headers: Headers) -> Client {
+        let mut client = self.clone();
+        client.headers = headers;
+        client
+    }
+
+    pub fn set_app_info(&mut self, name: String, version: Option<String>, url: Option<String>) {
+        self.app_info = Some(AppInfo { name, url, version });
+    }
+
+    /// Sets a value for the Stripe-Account header
+    ///
+    /// This is recommended if you are acting as only one Account for the lifetime of the client.
+    /// Otherwise, prefer `client.with(Headers{stripe_account: "acct_ABC", ..})`.
+    pub fn set_stripe_account<S: Into<String>>(&mut self, account_id: S) {
+        self.headers.stripe_account = Some(account_id.into());
+    }
+
+    /// Make a `GET` http request with just a path
+    pub fn get<T: DeserializeOwned + Send + 'static>(&self, path: &str) -> Response<T> {
+        let url = self.url(path);
+        let mut req =
+            RequestBuilder::new().method("GET").uri(url).body(hyper::Body::empty()).unwrap();
+        *req.headers_mut() = self.headers();
+        send(&self.client, req)
+    }
+
+    /// Make a `GET` http request with url query parameters
+    pub fn get_query<T: DeserializeOwned + Send + 'static, P: serde::Serialize>(
+        &self,
+        path: &str,
+        params: P,
+    ) -> Response<T> {
+        let url = match self.url_with_params(path, params) {
+            Err(err) => return Box::pin(future::ready(Err(err))),
+            Ok(ok) => ok,
+        };
+        let mut req =
+            RequestBuilder::new().method("GET").uri(url).body(hyper::Body::empty()).unwrap();
+        *req.headers_mut() = self.headers();
+        send(&self.client, req)
+    }
+
+    /// Make a `DELETE` http request with just a path
+    pub fn delete<T: DeserializeOwned + Send + 'static>(&self, path: &str) -> Response<T> {
+        let url = self.url(path);
+        let mut req =
+            RequestBuilder::new().method("DELETE").uri(url).body(hyper::Body::empty()).unwrap();
+        *req.headers_mut() = self.headers();
+        send(&self.client, req)
+    }
+
+    /// Make a `DELETE` http request with url query parameters
+    pub fn delete_query<T: DeserializeOwned + Send + 'static, P: serde::Serialize>(
+        &self,
+        path: &str,
+        params: P,
+    ) -> Response<T> {
+        let url = match self.url_with_params(path, params) {
+            Err(err) => return Box::pin(future::ready(Err(err))),
+            Ok(ok) => ok,
+        };
+        let mut req =
+            RequestBuilder::new().method("DELETE").uri(url).body(hyper::Body::empty()).unwrap();
+        *req.headers_mut() = self.headers();
+        send(&self.client, req)
+    }
+
+    /// Make a `POST` http request with just a path
+    pub fn post<T: DeserializeOwned + Send + 'static>(&self, path: &str) -> Response<T> {
+        let url = self.url(path);
+        let mut req =
+            RequestBuilder::new().method("POST").uri(url).body(hyper::Body::empty()).unwrap();
+        *req.headers_mut() = self.headers();
+        send(&self.client, req)
+    }
+
+    /// Make a `POST` http request with urlencoded body
+    pub fn post_form<T: DeserializeOwned + Send + 'static, F: serde::Serialize>(
+        &self,
+        path: &str,
+        form: F,
+    ) -> Response<T> {
+        let url = self.url(path);
+        let mut req = RequestBuilder::new()
+            .method("POST")
+            .uri(url)
+            .body(match serde_qs::to_string(&form) {
+                Err(err) => return Box::pin(future::ready(Err(Error::serialize(err)))),
+                Ok(body) => hyper::Body::from(body),
+            })
+            .unwrap();
+        *req.headers_mut() = self.headers();
+        req.headers_mut().insert(
+            HeaderName::from_static("content-type"),
+            HeaderValue::from_str("application/x-www-form-urlencoded").unwrap(),
+        );
+        send(&self.client, req)
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}/{}", self.host, path.trim_start_matches('/'))
+    }
+
+    fn url_with_params<P: serde::Serialize>(&self, path: &str, params: P) -> Result<String, Error> {
+        let params = serde_qs::to_string(&params).map_err(Error::serialize)?;
+        Ok(format!("{}/{}?{}", self.host, &path[1..], params))
+    }
+
+    fn headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_str(&format!("Bearer {}", self.secret_key)).unwrap(),
+        );
+        if let Some(account) = &self.headers.stripe_account {
+            headers.insert(
+                HeaderName::from_static("stripe-account"),
+                HeaderValue::from_str(account).unwrap(),
+            );
+        }
+        if let Some(client_id) = &self.headers.client_id {
+            headers.insert(
+                HeaderName::from_static("client-id"),
+                HeaderValue::from_str(client_id).unwrap(),
+            );
+        }
+        if let Some(stripe_version) = &self.headers.stripe_version {
+            headers.insert(
+                HeaderName::from_static("stripe-version"),
+                HeaderValue::from_str(stripe_version.as_str()).unwrap(),
+            );
+        }
+        const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
+        let user_agent: String = format!("Stripe/v3 RustBindings/{}", CRATE_VERSION);
+        if let Some(app_info) = &self.app_info {
+            let formatted: String = format_app_info(app_info);
+            let user_agent_app_info: String =
+                format!("{} {}", user_agent, formatted).trim().to_owned();
+            headers.insert(
+                HeaderName::from_static("user-agent"),
+                HeaderValue::from_str(user_agent_app_info.as_str()).unwrap(),
+            );
+        } else {
+            headers.insert(
+                HeaderName::from_static("user-agent"),
+                HeaderValue::from_str(user_agent.as_str()).unwrap(),
+            );
+        };
+        headers
+    }
+}
+
+fn send<T: DeserializeOwned + Send + 'static>(
+    client: &HttpClient,
+    request: hyper::Request<hyper::Body>,
+) -> Response<T> {
+    let client = client.clone(); // N.B. Client is send sync;  cloned clients share the same pool.
+    Box::pin(async move {
+        let response = client.request(request).await?;
+        let status = response.status();
+        let bytes = hyper::body::to_bytes(response.into_body()).await?;
+        if !status.is_success() {
+            let mut err = serde_json::from_slice(&bytes).unwrap_or_else(|err| {
+                let mut req = ErrorResponse { error: RequestError::default() };
+                req.error.message = Some(format!("failed to deserialize error: {}", err));
+                req
+            });
+            err.error.http_status = status.as_u16();
+            Err(Error::from(err.error))?;
+        }
+        serde_json::from_slice(&bytes).map_err(Error::deserialize)
+    })
+}
+
+/// Formats a plugin's 'App Info' into a string that can be added to the end of an User-Agent string.
+///
+/// This formatting matches that of other libraries, and if changed then it should be changed everywhere.
+fn format_app_info(info: &AppInfo) -> String {
+    let formatted: String = match (&info.version, &info.url) {
+        (Some(a), Some(b)) => format!("{}/{} ({})", &info.name, a, b),
+        (Some(a), None) => format!("{}/{}", &info.name, a),
+        (None, Some(b)) => format!("{}/{}", &info.name, b),
+        _ => info.name.to_string(),
+    };
+    formatted
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,17 @@
 #![allow(clippy::large_enum_variant)]
 
 mod client {
-    pub mod r#async;
-    #[cfg(feature = "blocking")]
+    #[cfg(any(
+        feature = "runtime-tokio-hyper",
+        feature = "runtime-tokio-hyper-rustls",
+        feature = "runtime-blocking",
+    ))]
+    pub mod tokio;
+
+    #[cfg(feature = "runtime-async-std-surf")]
+    pub mod async_std;
+
+    #[cfg(feature = "runtime-blocking")]
     pub mod blocking;
 }
 
@@ -82,7 +91,7 @@ pub use crate::params::{
 };
 pub use crate::resources::*;
 
-#[cfg(feature = "blocking")]
+#[cfg(feature = "runtime-blocking")]
 mod config {
     pub(crate) use crate::client::blocking::{err, ok};
     pub type Client = crate::client::blocking::Client;
@@ -104,11 +113,18 @@ mod config {
     pub type Response<T> = crate::client::blocking::Response<T>;
 }
 
-#[cfg(not(feature = "blocking"))]
+#[cfg(any(feature = "runtime-tokio-hyper", feature = "runtime-tokio-hyper-rustls",))]
 mod config {
-    pub(crate) use crate::client::r#async::{err, ok};
-    pub type Client = crate::client::r#async::Client;
-    pub type Response<T> = crate::client::r#async::Response<T>;
+    pub(crate) use crate::client::tokio::{err, ok};
+    pub type Client = crate::client::tokio::Client;
+    pub type Response<T> = crate::client::tokio::Response<T>;
+}
+
+#[cfg(feature = "runtime-async-std-surf")]
+mod config {
+    pub(crate) use crate::client::async_std::{err, ok};
+    pub type Client = crate::client::async_std::Client;
+    pub type Response<T> = crate::client::async_std::Response<T>;
 }
 
 pub use self::config::Client;


### PR DESCRIPTION
These commits add a new runtime system (modelled on `sqlx`) so that you can pick the underlying client. Runtimes are selected as features. As of now, there are 5 runtimes:

```toml
[features]
runtime-tokio-hyper = ["tokio", "hyper", "hyper-tls"]
runtime-tokio-hyper-rustls = ["tokio", "hyper", "hyper-rustls"]
runtime-blocking = ["tokio", "tokio/rt-core", "hyper", "hyper-tls"]
runtime-blocking-rustls = ["tokio", "tokio/rt-core", "hyper", "hyper-rustls"]
runtime-async-std-surf = ["async-std", "surf"]
```

The only outstanding issue is reconciling the error handling between the blocking, hyper, and surf apis.

Closes #150