### PR TITLE
Add BankAccountVerificationFailed to ErrorCode enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -187,6 +187,7 @@ pub enum ErrorCode {
     BankAccountExists,
     BankAccountUnusable,
     BankAccountUnverified,
+    BankAccountVerificationFailed,
     BitcoinUpgradeRequired,
     CardDeclined,
     ChargeAlreadyCaptured,


### PR DESCRIPTION
This error can be returned when verifying a bank account.