### PR TITLE
Update to Tokio 1.0 and Hyper 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ sha2 = { version = "0.8", optional = true }
 
 [[example]]
 name = "async_create_charge"
-#required-features = ["async"]
+required-features = ["async"]
 
 [[example]]
 name = "create_charge"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,15 +76,15 @@ serde_derive = "1.0.79"
 serde_json = "1.0"
 serde_qs = "0.5"
 smol_str = "0.1"
-tokio = { version = "1", default-features = false, features = ["net", "time"] }
+tokio = "1"
 
 # Webhook support
 hmac = { version = "0.7", optional = true }
 sha2 = { version = "0.8", optional = true }
 
-[[example]]
-name = "async_create_charge"
-required-features = ["async"]
+#[[example]]
+#name = "async_create_charge"
+#required-features = ["async"]
 
 [[example]]
 name = "create_charge"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/sh
 
 
-.PHONY: build-full-blocking build-rustls-tls build-full-async test-full-async test-full-blocking test-rustls-tls
+.PHONY: preinstall build-full-blocking build-rustls-tls build-full-async test-full-async test-full-blocking test-rustls-tls
 
 preinstall:
 	bash preinstall.sh
@@ -31,3 +31,4 @@ build-rustls-tls: preinstall
 test-rustls-tls: build-rustls-tls
 	cargo test --verbose --no-default-features --features "full webhook-events blocking rustls-tls" --workspace --exclude binary_size
 
+all: test-full-blocking test-full-async test-rustls-tls

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+SHELL := /bin/sh
+
+
+.PHONY: build-full-blocking build-rustls-tls build-full-async test-full-async test-full-blocking test-rustls-tls
+
+preinstall:
+	bash preinstall.sh
+
+build-no-default-features: preinstall
+	# Check "no default features"
+	cargo build --verbose --workspace --exclude binary_size --no-default-features --features default-tls
+
+build-full-blocking: preinstall
+	# Check "full/blocking"
+	cargo build --verbose --workspace --exclude binary_size
+
+test-full-blocking: build-full-blocking
+	cargo test --verbose --workspace --exclude binary_size
+
+build-full-async: preinstall
+	# Check "full/async"
+	cargo build --verbose --features async --workspace --exclude binary_size
+
+test-full-async: build-full-async
+	cargo test --verbose --features async --example async_create_charge
+
+build-rustls-tls: preinstall
+	# Check "full/blocking"
+	cargo build --verbose --no-default-features --features "full webhook-events blocking rustls-tls" --workspace --exclude binary_size
+
+test-rustls-tls: build-rustls-tls
+	cargo test --verbose --no-default-features --features "full webhook-events blocking rustls-tls" --workspace --exclude binary_size
+

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 [dependencies]
 heck = "0.3"
 lazy_static = "1"
-reqwest = { version = "0.10", features = ["blocking"] }
+reqwest = { version = "0.11", features = ["blocking"] }
 regex = "1"
 serde_json = "1"

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -1,7 +1,5 @@
 export STRIPE_MOCK_VERSION=0.90.0
 
-rm -rf stripe-mock
-
 if [[ "$OSTYPE" == "darwin"* ]]; then
   export TARGET=darwin_amd64
 else

--- a/preinstall.sh
+++ b/preinstall.sh
@@ -1,0 +1,16 @@
+export STRIPE_MOCK_VERSION=0.90.0
+
+rm -rf stripe-mock
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  export TARGET=darwin_amd64
+else
+  export TARGET=linux_amd64
+fi
+
+if [ ! -d "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}" ]; then
+  mkdir -p stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/
+  curl -L "https://github.com/stripe/stripe-mock/releases/download/v${STRIPE_MOCK_VERSION}/stripe-mock_${STRIPE_MOCK_VERSION}_${TARGET}.tar.gz" -o "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}_${TARGET}.tar.gz"
+  tar -zxf "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}_${TARGET}.tar.gz" -C "stripe-mock/stripe-mock_${STRIPE_MOCK_VERSION}/"
+fi
+

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -52,7 +52,7 @@ impl Client {
     pub fn from_url(scheme_host: impl Into<String>, secret_key: impl Into<String>) -> Client {
         let url = scheme_host.into();
         let host = if url.ends_with('/') { format!("{}v1", url) } else { format!("{}/v1", url) };
-        let https = HttpsConnector::new();
+        let https = HttpsConnector::with_native_roots();
         let client = hyper::Client::builder().build(https);
         let mut headers = Headers::default();
         // TODO: Automatically determine the latest supported api version in codegen?

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -1,21 +1,36 @@
-use crate::error::{Error, ErrorResponse, RequestError};
-use crate::params::{AppInfo, Headers};
-use crate::resources::ApiVersion;
+use std::future::Future;
+use std::pin::Pin;
+
+use hyper::client::HttpConnector;
+use hyper::client::connect::dns::GaiResolver;
 use futures_util::future;
 use http::header::{HeaderMap, HeaderName, HeaderValue};
 use http::request::Builder as RequestBuilder;
 use serde::de::DeserializeOwned;
-use std::future::Future;
-use std::pin::Pin;
+
+use crate::error::{Error, ErrorResponse, RequestError};
+use crate::params::{AppInfo, Headers};
+use crate::resources::ApiVersion;
 
 #[cfg(feature = "rustls-tls")]
 use hyper_rustls::HttpsConnector;
 #[cfg(feature = "default-tls")]
 use hyper_tls::HttpsConnector;
+
 #[cfg(all(feature = "default-tls", feature = "rustls-tls"))]
 compile_error!("You must enable only one TLS implementation");
 #[cfg(not(any(feature = "default-tls", feature = "rustls-tls")))]
 compile_error!("You must enable at least one TLS implementation; add `features = [\"default-tls\"]` to your Cargo.toml");
+
+#[cfg(feature = "rustls-tls")]
+fn new_connector() -> hyper_rustls::HttpsConnector<HttpConnector<GaiResolver>> {
+    hyper_rustls::HttpsConnector::with_native_roots()
+}
+
+#[cfg(feature = "default-tls")]
+fn new_connector() -> hyper_tls::HttpsConnector<HttpConnector<GaiResolver>> {
+    hyper_tls::HttpsConnector::new()
+}
 
 type HttpClient = hyper::Client<HttpsConnector<hyper::client::HttpConnector>, hyper::Body>;
 
@@ -52,7 +67,7 @@ impl Client {
     pub fn from_url(scheme_host: impl Into<String>, secret_key: impl Into<String>) -> Client {
         let url = scheme_host.into();
         let host = if url.ends_with('/') { format!("{}v1", url) } else { format!("{}/v1", url) };
-        let https = HttpsConnector::with_native_roots();
+        let https = new_connector();
         let client = hyper::Client::builder().build(https);
         let mut headers = Headers::default();
         // TODO: Automatically determine the latest supported api version in codegen?

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -11,7 +11,6 @@ use serde::de::DeserializeOwned;
 use crate::error::{Error, ErrorResponse, RequestError};
 use crate::params::{AppInfo, Headers};
 use crate::resources::ApiVersion;
-
 #[cfg(feature = "rustls-tls")]
 use hyper_rustls::HttpsConnector;
 #[cfg(feature = "default-tls")]

--- a/src/client/async.rs
+++ b/src/client/async.rs
@@ -11,11 +11,11 @@ use serde::de::DeserializeOwned;
 use crate::error::{Error, ErrorResponse, RequestError};
 use crate::params::{AppInfo, Headers};
 use crate::resources::ApiVersion;
+
 #[cfg(feature = "rustls-tls")]
 use hyper_rustls::HttpsConnector;
 #[cfg(feature = "default-tls")]
 use hyper_tls::HttpsConnector;
-
 #[cfg(all(feature = "default-tls", feature = "rustls-tls"))]
 compile_error!("You must enable only one TLS implementation");
 #[cfg(not(any(feature = "default-tls", feature = "rustls-tls")))]

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -39,10 +39,9 @@ impl Client {
     }
 
     fn from_async(inner: AsyncClient) -> Client {
-        let runtime = tokio::runtime::Builder::new()
+        let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_io()
             .enable_time() // use separate `io/time` instead of `all` to ensure `tokio/time` is enabled
-            .basic_scheduler()
             .build()
             .unwrap();
         Client { inner, runtime: Arc::new(RefCell::new(runtime)) }

--- a/tests/mock/mod.rs
+++ b/tests/mock/mod.rs
@@ -21,7 +21,9 @@ where
 
     drop(keep_alive);
     teardown();
-    assert!(result.is_ok())
+    if let Err(err) = result {
+        panic!("{:?}", err)
+    };
 }
 
 fn setup() -> Arc<Mutex<Option<Child>>> {


### PR DESCRIPTION
The main work here involves translating any Tokio 0.2 features to Tokio 1.0. The Tokio 1.0 API is essentially a declared-stable (and modified) 0.3 API, whereas upgrading from 0.2 to 0.3/1.0 has a non-trivial number of breaking changes to the API.

I'd starting this effort by translating the Tokio 0.2 crate features into what's offered with 1.0, as well as updated the instantiation of the HTTP connector (either hyper-[rus]tls). All but one of the test, which checks for functional `Expand` parameter behavior, currently pass. 

Resolves #155

`$ cargo check` works, however it seems I have the features mis-configured, as `$ cargo test` is showing failures related to using async vs blocking methods:

```rust
// ...old code error removed...
// see below for more recent issues :)
```

Edit: I found the commands for invoking the test in `.travis.yml` and have since added a Makefile to more easily run these commands. You can use the following `make` targets with `$ make target-name`
* `preinstall`: downloads the correct target of stripe_mock based on host
* `build-no-default-features`: build with only default-tls enabled
* `build-full-blocking`: build with default features
* `test-full-blocking`: test with default features
* `build-full-async`: build with async enabled (seeing failures during testing)
* `test-full-async`: test with async enabled (also seeing failures here)
* `build-rustls-tls`: build with no features except [full, webhook-events, blocking, rustls-tls]
* `test-full-blocking`: test with no features except [full, webhook-events, blocking, rustls-tls]
These correspond to the steps defined in the TravisCI pipeline, so it makes for easy usage there as well as during development.

All targets besides `preinstall` depend on `preinstall`.