### PR TITLE
Add missing invoice.paid event

### DIFF
--- a/src/resources/event.rs
+++ b/src/resources/event.rs
@@ -97,6 +97,8 @@ pub enum EventType {
     InvoiceFinalized,
     #[serde(rename = "invoice.marked_uncollectible")]
     InvoiceMarkedUncollectible,
+    #[serde(rename = "invoice.paid")]
+    InvoicePaid,
     #[serde(rename = "invoice.payment_action_required")]
     InvoicePaymentActionRequired,
     #[serde(rename = "invoice.payment_failed")]


### PR DESCRIPTION
This change enables `stripe::Webhook::construct_event` to deserialize 'invoice.paid' events successfully.