### PR TITLE
Pin serde to 1.0.118

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ http = "0.2"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
 hyper-tls = { version = "0.4", optional = true }
 hyper-rustls = { version = "0.20", optional = true }
-serde = "=1.0.118" # N.B. we use `serde(other)` which was introduced in `1.0.79`
-serde_derive = "=1.0.118"
+serde = "<1.0.118, >=1.0.79" # N.B. we use `serde(other)` which was introduced in `1.0.79`
+serde_derive = "<1.0.118, >=1.0.79"
 serde_json = "1.0"
 serde_qs = "0.5"
 smol_str = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,8 @@ http = "0.2"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
 hyper-tls = { version = "0.4", optional = true }
 hyper-rustls = { version = "0.20", optional = true }
-serde = "1.0.79" # N.B. we use `serde(other)` which was introduced in `1.0.79`
-serde_derive = "1.0.79"
+serde = "=1.0.118" # N.B. we use `serde(other)` which was introduced in `1.0.79`
+serde_derive = "=1.0.118"
 serde_json = "1.0"
 serde_qs = "0.5"
 smol_str = "0.1"


### PR DESCRIPTION
Bypass issue in #158 , add `stripe-rust = { git = "https://github.com/seanpianka/stripe-rs.git", branch = "fix-serde" }` to Cargo.toml