### PR TITLE
Make PaymentSourceParams work with serde v1.0.119+

### DIFF
--- a/openapi/spec3.json
+++ b/openapi/spec3.json
@@ -2622,7 +2622,6 @@
           "metadata",
           "object",
           "paid",
-          "receipt_url",
           "refunded",
           "refunds",
           "status"

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -517,6 +517,7 @@ def_id!(RecipientId: String); // FIXME: This doesn't seem to be documented yet
 def_id!(RefundId, "re_");
 def_id!(ReviewId, "prv_");
 def_id!(ScheduledQueryRunId, "sqr_");
+def_id!(SessionId, "bps_");
 def_id!(SetupIntentId, "seti_");
 def_id!(SkuId, "sku_");
 def_id!(SourceId, "src_");

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -96,6 +96,8 @@ mod line_item_ext;
 #[cfg(feature = "billing")]
 mod plan;
 #[cfg(feature = "billing")]
+mod session_ext;
+#[cfg(feature = "billing")]
 mod subscription;
 #[cfg(feature = "billing")]
 mod subscription_ext;
@@ -123,6 +125,8 @@ pub use self::line_item::*;
 pub use self::line_item_ext::*;
 #[cfg(feature = "billing")]
 pub use self::plan::*;
+#[cfg(feature = "billing")]
+pub use self::session_ext::*;
 #[cfg(feature = "billing")]
 pub use self::subscription::*;
 #[cfg(feature = "billing")]

--- a/src/resources/charge.rs
+++ b/src/resources/charge.rs
@@ -147,7 +147,7 @@ pub struct Charge {
     ///
     /// The receipt is kept up-to-date to the latest state of the charge, including any refunds.
     /// If the charge is for an Invoice, the receipt will be stylized as an Invoice receipt.
-    pub receipt_url: String,
+    pub receipt_url: Option<String>,
 
     /// Whether the charge has been fully refunded.
     ///

--- a/src/resources/payment_source.rs
+++ b/src/resources/payment_source.rs
@@ -10,7 +10,8 @@ use serde_derive::{Deserialize, Serialize};
 ///
 /// Not to be confused with `SourceParams` which is used by `Source::create`
 /// to create a source that is not necessarily attached to a customer.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum PaymentSourceParams {
     /// Creates a payment method (e.g. card or bank account) from tokenized data,
     /// using a token typically received from Stripe Elements.
@@ -19,39 +20,6 @@ pub enum PaymentSourceParams {
     /// Attach an existing source to an existing customer or
     /// create a new customer from an existing source.
     Source(SourceId),
-}
-
-impl<'de> ::serde::Deserialize<'de> for PaymentSourceParams {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::de::Deserializer<'de>,
-    {
-        use serde::de::{Deserialize, Error};
-        use serde::private::de::{Content, ContentRefDeserializer};
-        let content = <Content<'_> as Deserialize>::deserialize(deserializer)?;
-        let deserializer = ContentRefDeserializer::<D::Error>::new(&content);
-        if let Ok(ok) = <SourceId as Deserialize>::deserialize(deserializer) {
-            return Ok(PaymentSourceParams::Source(ok));
-        }
-        let deserializer = ContentRefDeserializer::<D::Error>::new(&content);
-        if let Ok(ok) = <TokenId as Deserialize>::deserialize(deserializer) {
-            return Ok(PaymentSourceParams::Token(ok));
-        }
-
-        Err(Error::custom("data did not match any variant of enum PaymentSourceParams"))
-    }
-}
-
-impl<'a> ::serde::Serialize for PaymentSourceParams {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::ser::Serializer,
-    {
-        match self {
-            PaymentSourceParams::Source(id) => id.serialize(serializer),
-            PaymentSourceParams::Token(id) => id.serialize(serializer),
-        }
-    }
 }
 
 /// A PaymentSource represents a payment method _associated with a customer or charge_.

--- a/src/resources/session_ext.rs
+++ b/src/resources/session_ext.rs
@@ -1,0 +1,60 @@
+use crate::config::{Client, Response};
+use crate::ids::{CustomerId, SessionId};
+use crate::params::Timestamp;
+use serde_derive::{Deserialize, Serialize};
+
+/// Creates a session of the customer portal.
+///
+/// For more details see [https://stripe.com/docs/api/customer_portal/create](https://stripe.com/docs/api/customer_portal/create).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CreateSession {
+    /// The ID of an existing customer.
+    pub customer: CustomerId,
+
+    /// The URL to which Stripe should send customers when they click on the link to return to your website. This field is required if a default return URL has not been configured for the portal.
+    pub return_url: Option<String>,
+}
+
+/// The Session object.
+///
+/// A session describes the instantiation of the customer portal for a particular customer. By visiting the session's URL, the customer can manage their subscriptions and billing details. For security reasons, sessions are short-lived and will expire if the customer does not visit the URL. Create sessions on-demand when customers intend to manage their subscriptions and billing details.
+///
+/// For more details see [https://stripe.com/docs/api/customer_portal/object](https://stripe.com/docs/api/customer_portal/object).
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Session {
+    /// Unique identifier for the object.
+    pub id: SessionId,
+
+    /// String representing the object’s type. Objects of the same type share the same value.
+    pub object: String,
+
+    /// Time at which the object was created. Measured in seconds since the Unix epoch.
+    pub created: Timestamp,
+
+    /// The ID of the customer for this session.
+    pub customer: CustomerId,
+
+    /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+    pub livemode: bool,
+
+    /// The URL to which Stripe should send customers when they click on the link to return to your website.
+    pub return_url: String,
+
+    /// The short-lived URL of the session giving customers access to the customer portal.
+    pub url: String,
+}
+
+impl CreateSession {
+    pub fn new(customer: CustomerId) -> Self {
+        CreateSession { customer, return_url: None }
+    }
+}
+
+impl Session {
+    /// Creates a session of the customer portal.
+    ///
+    /// For more details see [https://stripe.com/docs/api/customer_portal/create](https://stripe.com/docs/api/customer_portal/create).
+    pub fn create(client: &Client, params: CreateSession) -> Response<Self> {
+        client.post_form(&format!("/billing_portal/sessions"), &params)
+    }
+}


### PR DESCRIPTION
This change makes the library compatible with newer versions of serde. It replaces the custom ser/deser implemntation for  `PaymentSourceParams` to [untagged enums](https://serde.rs/enum-representations.html#untagged). See #158 (credit to @arlyon)