### PR TITLE
Make PaymentSourceParams work with serde v1.0.119+

### DIFF
--- a/src/resources/payment_source.rs
+++ b/src/resources/payment_source.rs
@@ -10,7 +10,8 @@ use serde_derive::{Deserialize, Serialize};
 ///
 /// Not to be confused with `SourceParams` which is used by `Source::create`
 /// to create a source that is not necessarily attached to a customer.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum PaymentSourceParams {
     /// Creates a payment method (e.g. card or bank account) from tokenized data,
     /// using a token typically received from Stripe Elements.
@@ -19,39 +20,6 @@ pub enum PaymentSourceParams {
     /// Attach an existing source to an existing customer or
     /// create a new customer from an existing source.
     Source(SourceId),
-}
-
-impl<'de> ::serde::Deserialize<'de> for PaymentSourceParams {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: ::serde::de::Deserializer<'de>,
-    {
-        use serde::de::{Deserialize, Error};
-        use serde::private::de::{Content, ContentRefDeserializer};
-        let content = <Content<'_> as Deserialize>::deserialize(deserializer)?;
-        let deserializer = ContentRefDeserializer::<D::Error>::new(&content);
-        if let Ok(ok) = <SourceId as Deserialize>::deserialize(deserializer) {
-            return Ok(PaymentSourceParams::Source(ok));
-        }
-        let deserializer = ContentRefDeserializer::<D::Error>::new(&content);
-        if let Ok(ok) = <TokenId as Deserialize>::deserialize(deserializer) {
-            return Ok(PaymentSourceParams::Token(ok));
-        }
-
-        Err(Error::custom("data did not match any variant of enum PaymentSourceParams"))
-    }
-}
-
-impl<'a> ::serde::Serialize for PaymentSourceParams {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: ::serde::ser::Serializer,
-    {
-        match self {
-            PaymentSourceParams::Source(id) => id.serialize(serializer),
-            PaymentSourceParams::Token(id) => id.serialize(serializer),
-        }
-    }
 }
 
 /// A PaymentSource represents a payment method _associated with a customer or charge_.


### PR DESCRIPTION
This change makes the library compatible with newer versions of serde. It replaces the custom ser/deser implemntation for  `PaymentSourceParams` to [untagged enums](https://serde.rs/enum-representations.html#untagged). See #158 (credit to @arlyon)