### PR TITLE
Support dispute ids with a `du_` prefix

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -487,7 +487,7 @@ def_id!(CheckoutSessionId, "cs_");
 def_id!(CheckoutSessionItemId: String); // TODO: Figure out what prefix this id has
 def_id!(CouponId: String); // N.B. A coupon id can be user-provided so can be any arbitrary string
 def_id!(CustomerId, "cus_");
-def_id!(DisputeId, "dp_");
+def_id!(DisputeId, "dp_" | "du_");
 def_id!(EventId, "evt_");
 def_id!(FileId, "file_");
 def_id!(FileLinkId, "link_");


### PR DESCRIPTION
Like refunds (and many others): https://github.com/wyyerd/stripe-rs/pull/177 there appears to be multiple ID prefixes that stripe uses for disputes.

This change specifically allows `du_` as a prefix for dispute ids.