### PR TITLE
add `transfer_data` field to `PaymentIntentUpdateParams`

### DIFF
--- a/src/resources/charge.rs
+++ b/src/resources/charge.rs
@@ -621,3 +621,9 @@ pub struct TransferDataParams {
 
     pub destination: String,
 }
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TransferDataUpdateParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<i64>,
+}

--- a/src/resources/payment_intent.rs
+++ b/src/resources/payment_intent.rs
@@ -5,6 +5,7 @@ use crate::resources::{
     Account, Application, Charge, Currency, Customer, Invoice, PaymentIntentOffSession,
     PaymentMethod, PaymentSource, Review, Shipping, TransferDataParams,
 };
+use crate::TransferDataUpdateParams;
 use serde_derive::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PaymentIntent".
@@ -480,6 +481,8 @@ pub struct PaymentIntentUpdateParams<'a> {
     pub source: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transfer_group: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transfer_data: Option<TransferDataUpdateParams>,
 }
 
 /// The set of parameters that can be used when confirming a payment_intent object.

--- a/src/resources/setup_intent.rs
+++ b/src/resources/setup_intent.rs
@@ -266,23 +266,20 @@ pub struct CreateSetupIntent<'a> {
     /// If this hash is populated, this SetupIntent will generate a single_use Mandate on success.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub single_use: Option<CreateSetupIntentSingleUse>,
+    
+    /// Indicates how the payment method is intended to be used in the future.
+    ///
+    /// Use `on_session` if you intend to only reuse the payment method when the customer is in your checkout flow.
+    ///
+    /// Use `off_session` if your customer may or may not be in your checkout flow.
+    /// If not provided, this value defaults to `off_session`.
+    pub usage: String
 }
 
 impl<'a> CreateSetupIntent<'a> {
     pub fn new() -> Self {
         CreateSetupIntent {
-            confirm: Default::default(),
-            customer: Default::default(),
-            description: Default::default(),
-            expand: Default::default(),
-            mandate_data: Default::default(),
-            metadata: Default::default(),
-            on_behalf_of: Default::default(),
-            payment_method: Default::default(),
-            payment_method_options: Default::default(),
-            payment_method_types: Default::default(),
-            return_url: Default::default(),
-            single_use: Default::default(),
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
Add the field to update [transfer_data](https://stripe.com/docs/api/payment_intents/update#update_payment_intent-transfer_data) when updating a payment intent.

I think I may have put `TransferDataUpdateParams` in the wrong spot. Let me know if I should move it.