### PR TITLE
Add a note about actix to the README and the library docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ stripe-rust = { version = "*", default-features = false, features = ["default-tl
 Refer to the [Stripe API docs](https://stripe.com/docs/api) to determine
 which APIs are included as part of each feature flag.
 
+
+### Async Dependencies
+This crate depends on `tokio=1`. Users of the `stripe-rs` async client will need
+all of their dependencies to be compatible with the >1.0 release of `tokio`. The
+`actix` framework is one notable dependency that hasn't released a stable
+version compatible with tokio 1.0 yet, so you will have to use one of their
+[beta releases](https://docs.rs/actix-web/4.0.0-beta.9/actix_web/) to make
+Stripe calls in an `actix` handler.
+
+Other libraries you depend on may also bring an outdated async runtime. You can
+track these down with `cargo tree` and search crates.io to find suitable updates:
+
+``` sh
+cargo tree | grep "tokio v0"
+```
+
 ## Contributing
 
 ### Code Generation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,22 @@
 //! let charges = stripe::Charge::list(&client, params).unwrap();
 //! println!("{:?}", charges); // =>  List { data: [Charge { id: "ch_12345", .. }] }
 //! ```
+//!
+//! ### A note about async ecosystem dependencies
+//!
+//! This crate depends on `tokio=1`. Users of the `stripe-rs` async client will need
+//! all of their dependencies to be compatible with the >1.0 release of `tokio`. The
+//! `actix` framework is one notable dependency that hasn't released a stable
+//! version compatible with tokio 1.0 yet, so you will have to use one of their
+//! [beta releases](https://docs.rs/actix-web/4.0.0-beta.9/actix_web/) to make
+//! Stripe calls in an `actix` handler.
+//!
+//! Other libraries you depend on may also bring an outdated async runtime. You can
+//! track these down with `cargo tree` and search crates.io to find suitable updates:
+//!
+//! ``` sh
+//! cargo tree | grep "tokio v0"
+//! ```
 
 #![allow(clippy::map_clone)]
 // N.B. not sure if this rule will break compatibility with older rust versions we might want to support


### PR DESCRIPTION
Closes #153 

This MR adds a note about actix, which depends on an old and incompatible version of `tokio`. The question of how to use stripe and actix together has come up a couple of times in the issue tracker.

- https://github.com/wyyerd/stripe-rs/issues/191
- https://github.com/wyyerd/stripe-rs/issues/153

Testing done:
 - [x] Rerendered the docs.
 - [x] Followed the markdown link to make sure it's right. 