### PR TITLE
Add support for another payment-method event type

### DIFF
--- a/src/resources/event.rs
+++ b/src/resources/event.rs
@@ -139,6 +139,8 @@ pub enum EventType {
     PaymentIntentRequiresCapture,
     #[serde(rename = "payment_intent.succeeded")]
     PaymentIntentSucceeded,
+    #[serde(rename = "payment_method.automatically_updated")]
+    PaymentMethodAutomaticallyUpdated,
     #[serde(rename = "payment_method.attached")]
     PaymentMethodAttached,
     #[serde(rename = "payment_method.detached")]


### PR DESCRIPTION
Looks like I missed one of the new payment-method type events that Stripe can return.